### PR TITLE
Param preload

### DIFF
--- a/lib/ar_sync/ar_preload.rb
+++ b/lib/ar_sync/ar_preload.rb
@@ -86,7 +86,11 @@ module ARSync::ARPreload
           arg_hash = {}
           arg_hash[:context] = context if Util.block_has_keyword_arg?(preloader, :context)
           arg_hash[:params] = params if Util.block_has_keyword_arg?(preloader, :params)
-          [preloader, preloader.call(models, **arg_hash)]
+          if arg_hash.empty?
+            [preloader, preloader.call(models)]
+          else
+            [preloader, preloader.call(models, arg_hash)]
+          end
         end.to_h
 
         (include_id ? [[:id, {}], *attributes] : attributes).each do |name, sub_arg|

--- a/lib/ar_sync/core.rb
+++ b/lib/ar_sync/core.rb
@@ -20,7 +20,7 @@ module ARSync
     end
 
     def api_has_field(*args, &data_block)
-      preloadable_field *args, &data_block
+      preloadable_field(*args, &data_block)
     end
 
     def sync_has_one(*names, **option, &data_block)

--- a/test/preload_sample.rb
+++ b/test/preload_sample.rb
@@ -10,6 +10,17 @@ class Post
   } do |preload|
     preload[id] || 0
   end
+
+  preloadable_field :last_n_comments_with_preload, preload: lambda { |posts, params:|
+    Comment.where(post: posts).group_by(&:post_id).transform_values { |cs| cs.take(params) }
+  } do |preloaded, params:|
+    preloaded[id] || []
+  end
+
+  preloadable_field :last_n_comments do |params:|
+    p params
+    comments.limit(params)
+  end
 end
 
 class Comment
@@ -33,7 +44,7 @@ class Comment
     (preloaded[id] || 0) * 10
   end
 
-  preloadable_field :current_user_stars, preload: -> (comments, context) {
+  preloadable_field :current_user_stars, preload: -> (comments, context:) {
     Star.where(comment_id: comments.map(&:id), user_id: context[:current_user].id).group_by(&:comment_id)
   } do |preloadeds, _context|
     preloadeds[id] || []
@@ -44,8 +55,11 @@ class Star
   preloadable_field :id, :user
 end
 
-ARSync::ARPreload::Serializer.serialize User.first, [:id, posts: { comments: :stars_count }], context: { current_user: User.first }
-ARSync::ARPreload::Serializer.serialize User.first, [:id, posts: { title: { as: 'タイトル' }, user: { as: '作者', attributes: [:id, :name]} }]
+# ARSync::ARPreload::Serializer.serialize User.first, [:id, posts: { comments: [:stars_count, current_user_stars: :id] }], context: { current_user: User.first }
+ARSync::ARPreload::Serializer.serialize User.first, [:id, posts: { last_n_comments: [:id, params: 3] }]
+ARSync::ARPreload::Serializer.serialize User.first, [:id, posts: { last_n_comments_with_preload: [:id, params: 3] }]
+# ARSync::ARPreload::Serializer.serialize User.first, [:id, posts: { title: { as: 'タイトル' }, user: { as: '作者', attributes: [:id, :name]} }]
+
 # User Load (0.2ms)  SELECT  "users".* FROM "users" ORDER BY "users"."id" ASC LIMIT ?  [["LIMIT", 1]]
 # Post Load (0.3ms)  SELECT "posts".* FROM "posts" WHERE "posts"."user_id" = 1
 # Comment Load (2.9ms)  SELECT "comments".* FROM "comments" WHERE "comments"."post_id" IN (1, 7, 8, 10, 15)


### PR DESCRIPTION
serializerにcontextだけじゃなくparams(任意のオブジェクト)を渡せるようにする
使い道はこんな感じ
```
posts: [
  :id, :title, :body,
  user: :name,
  comments: [:id, :body, user: :name, params: { limit: 5, order: :desc }]
]
```