### PR TITLE
graph mode: No more sync keys in query

### DIFF
--- a/lib/ar_sync/class_methods.rb
+++ b/lib/ar_sync/class_methods.rb
@@ -192,6 +192,10 @@ module ArSync::GraphSync::ClassMethods
       ArSync.sync_graph_keys self, current_user
     end
 
+    _sync_define :defaults, namespace: :sync do |current_user|
+      { sync_keys: ArSync.sync_graph_keys(self, current_user) }
+    end
+
     before_destroy do
       @_sync_parents_info_before_mutation ||= _sync_current_parents_info
     end

--- a/lib/ar_sync/rails.rb
+++ b/lib/ar_sync/rails.rb
@@ -82,9 +82,9 @@ module ArSync
       _api_call :static do |model, current_user, query|
         case model
         when ArSync::Collection, ActiveRecord::Relation, Array
-          ArSync.serialize model.to_a, query, user: current_user
+          ArSerializer.serialize model.to_a, query, context: current_user
         when ActiveRecord::Base
-          ArSync.serialize model, query, user: current_user
+          ArSerializer.serialize model, query, context: current_user
         else
           model
         end

--- a/sampleapp/app/views/comments/show.html.slim
+++ b/sampleapp/app/views/comments/show.html.slim
@@ -1,9 +1,9 @@
 - if sampleapp_ar_sync_graph?
   javascript:
-    const currentUserQuery = ['sync_keys', 'name']
+    const currentUserQuery = 'name'
     const commentQuery = [
-      'sync_keys', 'body', 'post_id', 'reaction_summary',
-      { user: ['sync_keys', 'name'], my_reaction: ['sync_keys', 'kind'] }
+      'body', 'post_id', 'reaction_summary',
+      { user: 'name', my_reaction: 'kind' }
     ]
 - else
   javascript:

--- a/sampleapp/app/views/follows/index.html.slim
+++ b/sampleapp/app/views/follows/index.html.slim
@@ -3,8 +3,8 @@
     const currentUserQuery = [
       'sync_keys', 'name',
       {
-        followeds: ['sync_keys', { from: ['sync_keys', 'name', { as: 'user' }] }],
-        followings: ['sync_keys', { to: ['sync_keys', 'name', { as: 'user' }] }]
+        followeds: { from: ['name', { as: 'user' }] },
+        followings: { to: ['name', { as: 'user' }] }
       }
     ]
 - else

--- a/sampleapp/app/views/posts/show.html.slim
+++ b/sampleapp/app/views/posts/show.html.slim
@@ -1,14 +1,14 @@
 - if sampleapp_ar_sync_graph?
   javascript:
-    const currentUserQuery = ['sync_keys', 'name']
+    const currentUserQuery = 'name'
     const postQuery = [
-      'sync_keys', 'title', 'body', 'reaction_summary', 'created_at',
+      'title', 'body', 'reaction_summary', 'created_at',
       {
-        user: ['sync_keys', 'name'],
-        my_reaction: ['sync_keys', 'kind'],
+        user: 'name',
+        my_reaction: 'kind',
         comments: [
-          'sync_keys', 'body', 'reaction_summary',
-          { user: ['sync_keys', 'name'], my_reaction: ['sync_keys', 'kind'] }
+          'body', 'reaction_summary',
+          { user: 'name', my_reaction: 'kind' }
         ]
       }
     ]

--- a/sampleapp/app/views/top/show.html.slim
+++ b/sampleapp/app/views/top/show.html.slim
@@ -1,10 +1,10 @@
 - if sampleapp_ar_sync_graph?
   javascript:
     const currentUserQuery = [
-      'sync_keys', 'name', 'followed_count', 'following_count',
-      { posts: ['sync_keys', 'title', 'comments_count', 'created_at'] }
+      'name', 'followed_count', 'following_count',
+      { posts: ['title', 'comments_count', 'created_at'] }
     ]
-    const postsQuery = ['sync_keys', 'title', 'created_at', 'comments_count', { user: ['sync_keys', 'name']}]
+    const postsQuery = ['title', 'created_at', 'comments_count', { user: ['name']}]
 - else
   javascript:
     const currentUserQuery = [

--- a/sampleapp/app/views/users/show.html.slim
+++ b/sampleapp/app/views/users/show.html.slim
@@ -1,12 +1,12 @@
 - if sampleapp_ar_sync_graph?
   javascript:
-    const currentUserQuery = ['sync_keys', 'name']
+    const currentUserQuery = 'name'
     const userQuery = [
-      'sync_keys', 'name', 'is_following', 'is_followed',
+      'name', 'is_following', 'is_followed',
       {
         posts: [
-          'sync_keys', 'title', 'comments_count', 'created_at',
-          { comments_last5: ['sync_keys', 'body', { user: ['sync_keys', 'name'] }, { as: 'recent_comments', params: { limit: 3 }}] }
+          'title', 'comments_count', 'created_at',
+          { comments_last5: ['body', { user: 'name' }, { as: 'recent_comments', params: { limit: 3 }}] }
         ]
       }
     ]

--- a/src/graph/ArSyncStore.ts
+++ b/src/graph/ArSyncStore.ts
@@ -197,44 +197,39 @@ class ArSyncRecord extends ArSyncContainerBase {
       const aliasName = subQuery.as || key
       const subData = data[aliasName]
       if (key === 'sync_keys') continue
-      if (subQuery.attributes && subQuery.attributes.sync_keys) {
-        if (subData instanceof Array || (subData && subData.collection && subData.order)) {
-          if (this.children[aliasName]) {
-            this.children[aliasName].replaceData(subData, this.sync_keys)
-          } else {
-            const collection = new ArSyncCollection(this.sync_keys, key, subQuery, subData, null, this.root)
-            this.mark()
-            this.children[aliasName] = collection
-            this.data[aliasName] = collection.data
-            collection.parentModel = this
-            collection.parentKey = aliasName
-          }
+      if (subQuery.attributes && (subData instanceof Array || (subData && subData.collection && subData.order))) {
+        if (this.children[aliasName]) {
+          this.children[aliasName].replaceData(subData, this.sync_keys)
         } else {
-          this.paths.push(key)
-          if (subData) {
-            if (this.children[aliasName]) {
-              this.children[aliasName].replaceData(subData)
-            } else {
-              const model = new ArSyncRecord(subQuery, subData, null, this.root)
-              this.mark()
-              this.children[aliasName] = model
-              this.data[aliasName] = model.data
-              model.parentModel = this
-              model.parentKey = aliasName
-            }
-          } else {
-            if(this.children[aliasName]) this.children[aliasName].release()
-            delete this.children[aliasName]
-            if (this.data[aliasName]) {
-              this.mark()
-              this.data[aliasName] = null
-            }
-          }
+          const collection = new ArSyncCollection(this.sync_keys, key, subQuery, subData, null, this.root)
+          this.mark()
+          this.children[aliasName] = collection
+          this.data[aliasName] = collection.data
+          collection.parentModel = this
+          collection.parentKey = aliasName
         }
       } else {
-        if (this.data[aliasName] !== subData) {
-          this.mark()
-          this.data[aliasName] = subData
+        if (subQuery.attributes) this.paths.push(key);
+        if (subData && subData.sync_keys) {
+          if (this.children[aliasName]) {
+            this.children[aliasName].replaceData(subData)
+          } else {
+            const model = new ArSyncRecord(subQuery, subData, null, this.root)
+            this.mark()
+            this.children[aliasName] = model
+            this.data[aliasName] = model.data
+            model.parentModel = this
+            model.parentKey = aliasName
+          }
+        } else {
+          if(this.children[aliasName]) {
+            this.children[aliasName].release()
+            delete this.children[aliasName]
+          }
+          if (this.data[aliasName] !== subData) {
+            this.mark()
+            this.data[aliasName] = subData
+          }
         }
       }
     }
@@ -284,7 +279,11 @@ class ArSyncRecord extends ArSyncContainerBase {
     for (const key in this.query.attributes) {
       if (key === 'sync_keys') continue
       const val = this.query.attributes[key]
-      if (!val || !val.attributes || !val.attributes.sync_keys) reloadQuery.attributes.push(key)
+      if (!val || !val.attributes) {
+        reloadQuery.attributes.push(key)
+      } else if (!val.params && Object.keys(val.attributes).length === 0) {
+        reloadQuery.attributes.push({ [key]: val })
+      }
     }
     return reloadQuery
   }

--- a/vendor/assets/javascripts/ar_sync_graph.js.erb
+++ b/vendor/assets/javascripts/ar_sync_graph.js.erb
@@ -2,7 +2,7 @@
   var exports = {}
   var modules = {}
   function require(name) { return modules[name] }
-  <% require = -> (path) { File.read File.dirname(__FILE__) + "/../../../#{path}" } %>
+  <% require = -> (path) { path = File.dirname(__FILE__) + "/../../../#{path}"; depend_on path; File.read path } %>
   <%= require.call 'core/ArSyncApi.js' %>
   window.ArSyncAPI = exports.default
   modules['../core/ArSyncApi'] = { default: exports.default }

--- a/vendor/assets/javascripts/ar_sync_tree.js.erb
+++ b/vendor/assets/javascripts/ar_sync_tree.js.erb
@@ -2,7 +2,7 @@
   var exports = {}
   var modules = {}
   function require(name) { return modules[name] }
-  <% require = -> (path) { File.read File.dirname(__FILE__) + "/../../../#{path}" } %>
+  <% require = -> (path) { path = File.dirname(__FILE__) + "/../../../#{path}"; depend_on path; File.read path } %>
   <%= require.call 'core/ArSyncApi.js' %>
   window.ArSyncAPI = exports.default
   modules['../core/ArSyncApi'] = { default: exports.default }


### PR DESCRIPTION
graphモードだとsync_keys指定したものしか同期されないのは面倒なのでやめる
(treeモードでid指定したものしか同期されないのもどうにかしたいけどできるかなぁ)