### PR TITLE
Simplify data types

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/tompng/ar_serializer
-  revision: 2ebcc913b664074a6be972449134a72fc4dd20d7
+  revision: 14ca69d7fcda2cb9b22de5b8c197cf65c867b580
   specs:
     ar_serializer (0.1.0)
       activerecord
@@ -14,21 +14,21 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.2.2)
-      activesupport (= 5.2.2)
-    activerecord (5.2.2)
-      activemodel (= 5.2.2)
-      activesupport (= 5.2.2)
+    activemodel (5.2.3)
+      activesupport (= 5.2.3)
+    activerecord (5.2.3)
+      activemodel (= 5.2.3)
+      activesupport (= 5.2.3)
       arel (>= 9.0)
-    activesupport (5.2.2)
+    activesupport (5.2.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (9.0.0)
     coderay (1.1.2)
-    concurrent-ruby (1.1.4)
-    i18n (1.5.3)
+    concurrent-ruby (1.1.5)
+    i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     method_source (0.9.2)
     minitest (5.11.3)

--- a/core/DataType.d.ts
+++ b/core/DataType.d.ts
@@ -1,6 +1,3 @@
-declare type NonOptionalType<T> = {
-    [key in keyof T]-?: T[key];
-};
 declare type RecordType = {
     _meta?: {
         query: any;
@@ -9,7 +6,7 @@ declare type RecordType = {
 declare type Unpacked<T> = T extends {
     [K in keyof T]: infer U;
 } ? U : never;
-declare type DataTypeExtractField<BaseType, Key extends keyof BaseType> = NonOptionalType<BaseType>[Key] & {} extends RecordType ? (null extends BaseType[Key] ? {} | null : {}) : NonOptionalType<BaseType>[Key] extends RecordType[] ? {}[] : NonOptionalType<BaseType>[Key];
+declare type DataTypeExtractField<BaseType, Key extends keyof BaseType> = BaseType[Key] extends RecordType ? (null extends BaseType[Key] ? {} | null : {}) : BaseType[Key] extends RecordType[] ? {}[] : BaseType[Key];
 declare type DataTypeExtractFieldsFromQuery<BaseType, Fields> = '*' extends Fields ? {
     [key in Exclude<keyof BaseType, '_meta'>]: DataTypeExtractField<BaseType, key>;
 } : {
@@ -23,14 +20,15 @@ declare type DataTypeExtractFromQueryHash<BaseType, QueryType> = '*' extends key
 } : {
     [key in keyof QueryType]: (key extends keyof BaseType ? (QueryType[key] extends true ? DataTypeExtractField<BaseType, key> : DataTypeFromQuery<BaseType[key] & {}, QueryType[key]>) : ExtraFieldErrorType);
 };
-declare type _DataTypeFromQuery<BaseType, QueryType> = QueryType extends keyof BaseType | '*' ? DataTypeExtractFieldsFromQuery<NonOptionalType<BaseType>, QueryType> : QueryType extends Readonly<(keyof BaseType | '*')[]> ? DataTypeExtractFieldsFromQuery<NonOptionalType<BaseType>, Unpacked<QueryType>> : QueryType extends {
+declare type _DataTypeFromQuery<BaseType, QueryType> = QueryType extends keyof BaseType | '*' ? DataTypeExtractFieldsFromQuery<BaseType, QueryType> : QueryType extends Readonly<(keyof BaseType | '*')[]> ? DataTypeExtractFieldsFromQuery<BaseType, Unpacked<QueryType>> : QueryType extends {
     as: string;
 } ? {
     error: 'type for alias field is not supported';
-} | undefined : QueryType extends {
-    attributes: any;
-} ? DataTypeExtractFromQueryHash<BaseType, QueryType['attributes']> : DataTypeExtractFromQueryHash<BaseType, QueryType>;
-export declare type DataTypeFromQuery<BaseType, QueryType> = BaseType extends any[] ? _DataTypeFromQuery<BaseType[0], QueryType>[] : null extends BaseType ? _DataTypeFromQuery<BaseType & {}, QueryType> | null : _DataTypeFromQuery<BaseType & {}, QueryType>;
+} | undefined : DataTypeExtractFromQueryHash<BaseType, QueryType>;
+export declare type DataTypeFromQuery<BaseType, QueryType> = BaseType extends any[] ? CheckAttributesField<BaseType[0], QueryType>[] : null extends BaseType ? CheckAttributesField<BaseType & {}, QueryType> | null : CheckAttributesField<BaseType & {}, QueryType>;
+declare type CheckAttributesField<P, Q> = Q extends {
+    attributes: infer R;
+} ? _DataTypeFromQuery<P, R> : _DataTypeFromQuery<P, Q>;
 declare type IsAnyCompareLeftType = {
     __any: never;
 };

--- a/core/DataType.d.ts
+++ b/core/DataType.d.ts
@@ -3,7 +3,7 @@ declare type RecordType = {
         query: any;
     };
 };
-declare type Unpacked<T> = T extends {
+declare type Values<T> = T extends {
     [K in keyof T]: infer U;
 } ? U : never;
 declare type DataTypeExtractField<BaseType, Key extends keyof BaseType> = BaseType[Key] extends RecordType ? (null extends BaseType[Key] ? {} | null : {}) : BaseType[Key] extends RecordType[] ? {}[] : BaseType[Key];
@@ -20,7 +20,7 @@ declare type DataTypeExtractFromQueryHash<BaseType, QueryType> = '*' extends key
 } : {
     [key in keyof QueryType]: (key extends keyof BaseType ? (QueryType[key] extends true ? DataTypeExtractField<BaseType, key> : DataTypeFromQuery<BaseType[key] & {}, QueryType[key]>) : ExtraFieldErrorType);
 };
-declare type _DataTypeFromQuery<BaseType, QueryType> = QueryType extends keyof BaseType | '*' ? DataTypeExtractFieldsFromQuery<BaseType, QueryType> : QueryType extends Readonly<(keyof BaseType | '*')[]> ? DataTypeExtractFieldsFromQuery<BaseType, Unpacked<QueryType>> : QueryType extends {
+declare type _DataTypeFromQuery<BaseType, QueryType> = QueryType extends keyof BaseType | '*' ? DataTypeExtractFieldsFromQuery<BaseType, QueryType> : QueryType extends Readonly<(keyof BaseType | '*')[]> ? DataTypeExtractFieldsFromQuery<BaseType, Values<QueryType>> : QueryType extends {
     as: string;
 } ? {
     error: 'type for alias field is not supported';
@@ -33,13 +33,13 @@ declare type IsAnyCompareLeftType = {
     __any: never;
 };
 declare type CollectExtraFields<Type, Path> = IsAnyCompareLeftType extends Type ? null : Type extends ExtraFieldErrorType ? Path : Type extends (infer R)[] ? _CollectExtraFields<R> : Type extends object ? _CollectExtraFields<Type> : null;
-declare type _CollectExtraFields<Type> = keyof (Type) extends never ? null : Unpacked<{
+declare type _CollectExtraFields<Type> = keyof (Type) extends never ? null : Values<{
     [key in keyof Type]: CollectExtraFields<Type[key], [key]>;
 }>;
 declare type SelectString<T> = T extends string ? T : never;
-declare type _ValidateDataTypeExtraFileds<Extra, Type> = SelectString<Unpacked<Extra>> extends never ? Type : {
+declare type _ValidateDataTypeExtraFileds<Extra, Type> = SelectString<Values<Extra>> extends never ? Type : {
     error: {
-        extraFields: SelectString<Unpacked<Extra>>;
+        extraFields: SelectString<Values<Extra>>;
     };
 };
 declare type ValidateDataTypeExtraFileds<Type> = _ValidateDataTypeExtraFileds<CollectExtraFields<Type, []>, Type>;

--- a/src/core/DataType.ts
+++ b/src/core/DataType.ts
@@ -1,11 +1,10 @@
-type NonOptionalType<T> = { [key in keyof T]-?: T[key] } // TODO: remove ? from BaseType definitions
 type RecordType = { _meta?: { query: any } }
 type Unpacked<T> = T extends { [K in keyof T]: infer U } ? U : never
-type DataTypeExtractField<BaseType, Key extends keyof BaseType> = NonOptionalType<BaseType>[Key] & {} extends RecordType
+type DataTypeExtractField<BaseType, Key extends keyof BaseType> = BaseType[Key] extends RecordType
   ? (null extends BaseType[Key] ? {} | null : {})
-  : NonOptionalType<BaseType>[Key] extends RecordType[]
+  : BaseType[Key] extends RecordType[]
   ? {}[]
-  : NonOptionalType<BaseType>[Key]
+  : BaseType[Key]
 
 type DataTypeExtractFieldsFromQuery<BaseType, Fields> = '*' extends Fields
   ? { [key in Exclude<keyof BaseType, '_meta'>]: DataTypeExtractField<BaseType, key> }
@@ -34,9 +33,9 @@ type DataTypeExtractFromQueryHash<BaseType, QueryType> = '*' extends keyof Query
     }
 
 type _DataTypeFromQuery<BaseType, QueryType> = QueryType extends keyof BaseType | '*'
-  ? DataTypeExtractFieldsFromQuery<NonOptionalType<BaseType>, QueryType>
+  ? DataTypeExtractFieldsFromQuery<BaseType, QueryType>
   : QueryType extends Readonly<(keyof BaseType | '*')[]>
-  ? DataTypeExtractFieldsFromQuery<NonOptionalType<BaseType>, Unpacked<QueryType>>
+  ? DataTypeExtractFieldsFromQuery<BaseType, Unpacked<QueryType>>
   : QueryType extends { as: string }
   ? { error: 'type for alias field is not supported' } | undefined
   : DataTypeExtractFromQueryHash<BaseType, QueryType>

--- a/src/core/DataType.ts
+++ b/src/core/DataType.ts
@@ -1,5 +1,5 @@
 type RecordType = { _meta?: { query: any } }
-type Unpacked<T> = T extends { [K in keyof T]: infer U } ? U : never
+type Values<T> = T extends { [K in keyof T]: infer U } ? U : never
 type DataTypeExtractField<BaseType, Key extends keyof BaseType> = BaseType[Key] extends RecordType
   ? (null extends BaseType[Key] ? {} | null : {})
   : BaseType[Key] extends RecordType[]
@@ -35,7 +35,7 @@ type DataTypeExtractFromQueryHash<BaseType, QueryType> = '*' extends keyof Query
 type _DataTypeFromQuery<BaseType, QueryType> = QueryType extends keyof BaseType | '*'
   ? DataTypeExtractFieldsFromQuery<BaseType, QueryType>
   : QueryType extends Readonly<(keyof BaseType | '*')[]>
-  ? DataTypeExtractFieldsFromQuery<BaseType, Unpacked<QueryType>>
+  ? DataTypeExtractFieldsFromQuery<BaseType, Values<QueryType>>
   : QueryType extends { as: string }
   ? { error: 'type for alias field is not supported' } | undefined
   : DataTypeExtractFromQueryHash<BaseType, QueryType>
@@ -63,12 +63,12 @@ type CollectExtraFields<Type, Path> = IsAnyCompareLeftType extends Type
   : null
 type _CollectExtraFields<Type> = keyof (Type) extends never
   ? null
-  : Unpacked<{ [key in keyof Type]: CollectExtraFields<Type[key], [key]>}>
+  : Values<{ [key in keyof Type]: CollectExtraFields<Type[key], [key]>}>
 
 type SelectString<T> = T extends string ? T : never
-type _ValidateDataTypeExtraFileds<Extra, Type> = SelectString<Unpacked<Extra>> extends never
+type _ValidateDataTypeExtraFileds<Extra, Type> = SelectString<Values<Extra>> extends never
   ? Type
-  : { error: { extraFields: SelectString<Unpacked<Extra>> } }
+  : { error: { extraFields: SelectString<Values<Extra>> } }
 type ValidateDataTypeExtraFileds<Type> = _ValidateDataTypeExtraFileds<CollectExtraFields<Type, []>, Type>
 
 type RequestBase = { api: string; query: any; params?: any; _meta?: { data: any } }

--- a/test/type_test.ts
+++ b/test/type_test.ts
@@ -39,3 +39,5 @@ const data13 = new ArSyncModel({ api: 'currentUser', query: { posts: { params: {
 data13.posts[0].title
 const data14 = new ArSyncModel({ api: 'currentUser', query: { posts: { params: { limit: 4 }, attributes: { id: true, title: true } } } }).data!
 data14.posts[0].title
+const data15 = new ArSyncModel({ api: 'currentUser', query: { posts: ['id', 'title'] } } as const).data!
+data15.posts[0].title


### PR DESCRIPTION
`TypeUser = { id?: number; name?: string }` → `{ id: number; name: string }`
と`?`が消えたので、その分シンプルにできる
as constのテスト追加