### PR TITLE
restore `dig`

### DIFF
--- a/core/ArSyncModelBase.d.ts
+++ b/core/ArSyncModelBase.d.ts
@@ -3,7 +3,7 @@ interface Request {
     query: any;
     params?: any;
 }
-declare type Path = (string | number)[];
+declare type Path = Readonly<(string | number)[]>;
 interface Change {
     path: Path;
     value: any;
@@ -20,6 +20,12 @@ interface Adapter {
     ondisconnect: () => void;
     onreconnect: () => void;
 }
+declare type PathFirst<P extends Readonly<any[]>> = ((...args: P) => void) extends (first: infer First, ...other: any) => void ? First : never;
+declare type PathRest<U> = U extends Readonly<any[]> ? ((...args: U) => any) extends (head: any, ...args: infer T) => any ? U extends Readonly<[any, any, ...any[]]> ? T : never : never : never;
+declare type DigResult<Data, P extends Readonly<any[]>> = Data extends null | undefined ? Data : PathFirst<P> extends never ? Data : PathFirst<P> extends keyof Data ? (Data extends Readonly<any[]> ? undefined : never) | {
+    0: Data[PathFirst<P>];
+    1: DigResult<Data[PathFirst<P>], PathRest<P>>;
+}[PathRest<P> extends never ? 0 : 1] : undefined;
 export default abstract class ArSyncModelBase<T> {
     private _ref;
     private _listenerSerial;
@@ -48,6 +54,8 @@ export default abstract class ArSyncModelBase<T> {
     subscribeOnce(event: SubscriptionType, callback: SubscriptionCallback): {
         unsubscribe: () => void;
     };
+    dig<P extends Path>(path: P): DigResult<T, P> | null;
+    static digData<Data, P extends Path>(data: Data, path: P): DigResult<Data, P>;
     subscribe(event: SubscriptionType, callback: SubscriptionCallback): {
         unsubscribe: () => void;
     };

--- a/core/ArSyncModelBase.js
+++ b/core/ArSyncModelBase.js
@@ -29,6 +29,23 @@ class ArSyncModelBase {
         });
         return subscription;
     }
+    dig(path) {
+        return ArSyncModelBase.digData(this.data, path);
+    }
+    static digData(data, path) {
+        if (path.length === 0)
+            return data;
+        if (data == null)
+            return data;
+        const key = path[0];
+        const other = path.slice(1);
+        if (Array.isArray(data)) {
+            return this.digData(data.find(el => el.id === key), other);
+        }
+        else {
+            return this.digData(data[key], other);
+        }
+    }
     subscribe(event, callback) {
         const id = this._listenerSerial++;
         const subscription = this._ref.model.subscribe(event, callback);

--- a/lib/ar_sync/type_script.rb
+++ b/lib/ar_sync/type_script.rb
@@ -57,9 +57,8 @@ module ArSync::TypeScript
       import { TypeRequest, ApiNameRequests } from './types'
       import { DataTypeFromRequest } from 'ar_sync/core/DataType'
       import ArSyncModelBase from 'ar_sync/#{mode}/ArSyncModel'
-      export default class ArSyncModel<R extends TypeRequest> extends ArSyncModelBase<{}> {
+      export default class ArSyncModel<R extends TypeRequest> extends ArSyncModelBase<DataTypeFromRequest<ApiNameRequests[R['api']], R>> {
         constructor(r: R) { super(r) }
-        data: DataTypeFromRequest<ApiNameRequests[R['api']], R> | null
       }
     CODE
   end

--- a/test/type_test.ts
+++ b/test/type_test.ts
@@ -41,3 +41,11 @@ const data14 = new ArSyncModel({ api: 'currentUser', query: { posts: { params: {
 data14.posts[0].title
 const data15 = new ArSyncModel({ api: 'currentUser', query: { posts: ['id', 'title'] } } as const).data!
 data15.posts[0].title
+
+const model = new ArSyncModel({ api: 'currentUser', query: { posts: ['id', 'title'] } } as const)
+let digId = model.dig(['posts', 0, 'id'] as const)
+let digTitle = model.dig(['posts', 0, 'title'] as const)
+digId = 1
+digTitle = 'title'
+digId = digTitle = undefined
+digId = digTitle = null


### PR DESCRIPTION
ts化したときにdigを消した(使ってなかった、型うまく書けなかった)のを復元

```js
postModel.dig(['comments', 3, 'user', 'name'])
```
will return
```ruby
post_model.data&.comments&.find{|c|c.id==3}&.user&.name
```

`comments[3]` ではなく `comments.find(c=>c.id===3)` (だからこそこのdigがあると便利だしないと面倒くさい)