### PR TITLE
子が更新された時の通知とデータ取得の効率化

### DIFF
--- a/lib/ar_sync/class_methods.rb
+++ b/lib/ar_sync/class_methods.rb
@@ -30,11 +30,11 @@ module ArSync::ClassMethodsBase
     superclass._each_sync_child(&block) if superclass < ActiveRecord::Base
   end
 
-  def sync_parent(parent, inverse_of:, only_to: nil)
+  def sync_parent(parent, inverse_of:, only_to: nil, watch: nil)
     _initialize_sync_callbacks
     _sync_parents_info << [
       parent,
-      { inverse_name: inverse_of, only_to: only_to }
+      { inverse_name: inverse_of, only_to: only_to, watch: watch }
     ]
   end
 end
@@ -189,6 +189,7 @@ module ArSync::GraphSync::ClassMethods
     mod = Module.new do
       def write_attribute(attr_name, value)
         self.class.default_scoped.scoping do
+          @_sync_watch_values_before_mutation ||= _sync_current_watch_values
           @_sync_parents_info_before_mutation ||= _sync_current_parents_info
           @_sync_belongs_to_info_before_mutation ||= _sync_current_belongs_to_info
         end
@@ -196,7 +197,7 @@ module ArSync::GraphSync::ClassMethods
       end
     end
     prepend mod
-    attr_reader :_sync_parents_info_before_mutation, :_sync_belongs_to_info_before_mutation
+    attr_reader :_sync_parents_info_before_mutation, :_sync_belongs_to_info_before_mutation, :_sync_watch_values_before_mutation
 
     _sync_define :id
 

--- a/lib/ar_sync/class_methods.rb
+++ b/lib/ar_sync/class_methods.rb
@@ -216,9 +216,9 @@ module ArSync::GraphSync::ClassMethods
     end
 
     before_save on: :create do
-      @_sync_parents_info_before_mutation ||= _sync_current_parents_info
-      @_sync_watch_values_before_mutation ||= _sync_current_watch_values
-      @_sync_belongs_to_info_before_mutation ||= _sync_current_belongs_to_info
+      @_sync_parents_info_before_mutation ||= {}
+      @_sync_watch_values_before_mutation ||= {}
+      @_sync_belongs_to_info_before_mutation ||= {}
     end
 
     %i[create update destroy].each do |action|

--- a/lib/ar_sync/class_methods.rb
+++ b/lib/ar_sync/class_methods.rb
@@ -187,7 +187,7 @@ module ArSync::GraphSync::ClassMethods
     return if instance_variable_defined? '@_sync_callbacks_initialized'
     @_sync_callbacks_initialized = true
     mod = Module.new do
-      def write_attribute(attr_name, value)
+      def _write_attribute(attr_name, value)
         self.class.default_scoped.scoping do
           @_sync_watch_values_before_mutation ||= _sync_current_watch_values
           @_sync_parents_info_before_mutation ||= _sync_current_parents_info
@@ -211,11 +211,13 @@ module ArSync::GraphSync::ClassMethods
 
     before_destroy do
       @_sync_parents_info_before_mutation ||= _sync_current_parents_info
+      @_sync_watch_values_before_mutation ||= _sync_current_watch_values
       @_sync_belongs_to_info_before_mutation ||= _sync_current_belongs_to_info
     end
 
     before_save on: :create do
       @_sync_parents_info_before_mutation ||= _sync_current_parents_info
+      @_sync_watch_values_before_mutation ||= _sync_current_watch_values
       @_sync_belongs_to_info_before_mutation ||= _sync_current_belongs_to_info
     end
 
@@ -223,6 +225,7 @@ module ArSync::GraphSync::ClassMethods
       after_commit on: action do
         next if ArSync.skip_notification?
         self.class.default_scoped.scoping { _sync_notify action }
+        @_sync_watch_values_before_mutation = nil
         @_sync_parents_info_before_mutation = nil
         @_sync_belongs_to_info_before_mutation = nil
       end

--- a/lib/ar_sync/collection.rb
+++ b/lib/ar_sync/collection.rb
@@ -51,9 +51,9 @@ class ArSync::Collection::Tree < ArSync::Collection
 end
 
 class ArSync::Collection::Graph < ArSync::Collection
-  def _sync_notify_child_changed(_child, _name, _to_user, _owned); end
+  def _sync_notify_child_changed(_name, _to_user); end
 
-  def _sync_notify_child_added(child, _name, to_user, _owned)
+  def _sync_notify_child_added(child, _name, to_user)
     ArSync.sync_graph_send to: self, action: :add, model: child, path: :collection, to_user: to_user
   end
 

--- a/lib/ar_sync/core.rb
+++ b/lib/ar_sync/core.rb
@@ -52,9 +52,10 @@ module ArSync
     end
   end
 
-  def self.sync_graph_send(to:, action:, model:, path: nil, to_user: nil)
+  def self.sync_graph_send(to:, action:, model:, path: nil, field: nil, to_user: nil)
     key = sync_graph_key to, to_user, signature: false
     e = { action: action }
+    e[:field] = field if field
     if model
       e[:class_name] = model.class.base_class.name
       e[:id] = model.id

--- a/lib/ar_sync/instance_methods.rb
+++ b/lib/ar_sync/instance_methods.rb
@@ -73,11 +73,7 @@ module ArSync::GraphSync::InstanceMethods
     values = {}
     self.class._each_sync_parent do |_, info|
       [*info[:watch]].each do |watch|
-        if watch.is_a? Proc
-          values[watch.to_s] = instance_exec(&watch)
-        else
-          values[watch.to_s] = send watch
-        end
+        values[watch] = watch.is_a?(Proc) ? instance_exec(&watch) : send(watch)
       end
     end
     values

--- a/lib/ar_sync/instance_methods.rb
+++ b/lib/ar_sync/instance_methods.rb
@@ -31,8 +31,10 @@ module ArSync::TreeSync::InstanceMethods
   end
 
   def _sync_notify_parent(action, path: nil, data: nil, order_param: nil, only_to_user: nil)
-    self.class._each_sync_parent do |parent, inverse_name:, only_to:|
-      parent = send(parent) if parent.is_a? Symbol
+    self.class._each_sync_parent do |parent, info|
+      inverse_name = info[:inverse_name]
+      only_to = info[:only_to]
+      parent = send parent if parent.is_a? Symbol
       parent = instance_exec(&parent) if parent.is_a? Proc
       next unless parent
       next if parent.respond_to?(:destroyed?) && parent.destroyed?
@@ -67,9 +69,23 @@ module ArSync::GraphSync::InstanceMethods
     _sync_notify_self if self.class._sync_self? && action == :update
   end
 
+  def _sync_current_watch_values
+    values = {}
+    self.class._each_sync_parent do |_, info|
+      [*info[:watch]].each do |watch|
+        if watch.is_a? Proc
+          values[watch.to_s] = instance_exec(&watch)
+        else
+          values[watch.to_s] = send watch
+        end
+      end
+    end
+    values
+  end
+
   def _sync_current_parents_info
     parents = []
-    self.class._each_sync_parent do |parent, inverse_name:, only_to:|
+    self.class._each_sync_parent do |parent, inverse_name:, only_to:, watch:|
       parent = send parent if parent.is_a? Symbol
       parent = instance_exec(&parent) if parent.is_a? Proc
       if only_to
@@ -78,7 +94,7 @@ module ArSync::GraphSync::InstanceMethods
       end
       inverse_name = instance_exec(&inverse_name) if inverse_name.is_a? Proc
       owned = parent.class._sync_child_info(inverse_name).present? if parent
-      parents << [parent, [inverse_name, to_user, owned]]
+      parents << [parent, [inverse_name, to_user, owned, watch]]
     end
     parents
   end
@@ -122,36 +138,42 @@ module ArSync::GraphSync::InstanceMethods
     else
       parents_was = _sync_parents_info_before_mutation
       parents = _sync_current_parents_info
+      column_values_was = _sync_watch_values_before_mutation
+      column_values = _sync_current_watch_values
     end
     parents_was.zip(parents).each do |(parent_was, info_was), (parent, info)|
-      if parent_was == parent && info_was == info
-        parent&._sync_notify_child_changed self, *info
-      else
-        parent_was&._sync_notify_child_removed self, *info_was
-        parent&._sync_notify_child_added self, *info
+      name, to_user, owned, watch = info
+      name_was, to_user_was, owned_was = info_was
+      if parent_was != parent || info_was != info
+        if owned_was
+          parent_was&._sync_notify_child_removed self, name_was, to_user_was
+        else
+          parent_was&._sync_notify_child_changed name_was, to_user_was
+        end
+        if owned
+          parent&._sync_notify_child_added self, name, to_user
+        else
+          parent&._sync_notify_child_changed name, to_user
+        end
+      elsif parent
+        changed = [*watch].any? do |w|
+          column_values_was[w] != column_values[w]
+        end
+        parent._sync_notify_child_changed name, to_user if changed
       end
     end
   end
 
-  def _sync_notify_child_removed(child, name, to_user, owned)
-    if owned
-      ArSync.sync_graph_send to: self, action: :remove, model: child, path: name, to_user: to_user
-    else
-      ArSync.sync_graph_send to: self, action: :update, model: self, to_user: to_user
-    end
+  def _sync_notify_child_removed(child, name, to_user)
+    ArSync.sync_graph_send to: self, action: :remove, model: child, path: name, to_user: to_user
   end
 
-  def _sync_notify_child_added(child, name, to_user, owned)
-    if owned
-      ArSync.sync_graph_send to: self, action: :add, model: child, path: name, to_user: to_user
-    else
-      ArSync.sync_graph_send to: self, action: :update, model: self, to_user: to_user
-    end
+  def _sync_notify_child_added(child, name, to_user)
+    ArSync.sync_graph_send to: self, action: :add, model: child, path: name, to_user: to_user
   end
 
-  def _sync_notify_child_changed(_child, _name, to_user, owned)
-    return if owned
-    ArSync.sync_graph_send(to: self, action: :update, model: self, to_user: to_user)
+  def _sync_notify_child_changed(name, to_user)
+    ArSync.sync_graph_send to: self, action: :update, model: self, field: name, to_user: to_user
   end
 
   def _sync_notify_self
@@ -160,8 +182,8 @@ module ArSync::GraphSync::InstanceMethods
     belongs.each do |name, info|
       next if belongs_was[name] == info
       value = info.key?(:value) ? info[:value] : _serializer_field_value(name)
-      _sync_notify_child_added value, name, nil, true if value.is_a? ArSerializer::Serializable
-      _sync_notify_child_removed value, name, nil, true if value.nil?
+      _sync_notify_child_added value, name, nil if value.is_a? ArSerializer::Serializable
+      _sync_notify_child_removed value, name, nil if value.nil?
     end
     ArSync.sync_graph_send(to: self, action: :update, model: self)
   end

--- a/test/model_graph.rb
+++ b/test/model_graph.rb
@@ -64,6 +64,11 @@ class Graph::Comment < Graph::BaseRecord
   sync_has_many :myStars, preload: :my_stars_loader do |preloaded|
     preloaded[id] || []
   end
+
+  sync_has_data :editedStarCount, preload: ->(comments) do
+    counts = Graph::Star.where('created_at != updated_at').where(comment_id: comments.map(&:id)).group(:comment_id).count
+    Hash.new(0).merge counts
+  end
 end
 
 class Graph::Star < Graph::BaseRecord
@@ -77,4 +82,5 @@ class Graph::Star < Graph::BaseRecord
   sync_parent :comment, inverse_of: :starCount
   sync_parent :comment, inverse_of: :myStar, only_to: -> { user }
   sync_parent :comment, inverse_of: :myStars, only_to: -> { user }
+  sync_parent :comment, inverse_of: :editedStarCount, watch: :updated_at
 end


### PR DESCRIPTION
子が変更された時
- 無駄に通知送ってたのをやめる
- 変更されたfield名も送って、必要な分だけreload