### PR TITLE
Model load by id

### DIFF
--- a/core/ArSyncStore.js
+++ b/core/ArSyncStore.js
@@ -130,7 +130,7 @@ class ArSyncContainerBase {
     static _load({ api, id, params, query }, root) {
         const parsedQuery = ArSyncRecord.parseQuery(query);
         if (id) {
-            return ModelBatchRequest.fetch(api, query, id).then(data => new ArSyncRecord(parsedQuery, data[0], null, root));
+            return ModelBatchRequest.fetch(api, query, id).then(data => new ArSyncRecord(parsedQuery, data, null, root));
         }
         else {
             const request = { api, query, params };

--- a/core/DataType.d.ts
+++ b/core/DataType.d.ts
@@ -46,15 +46,18 @@ declare type ValidateDataTypeExtraFileds<Type> = _ValidateDataTypeExtraFileds<Co
 declare type RequestBase = {
     api: string;
     query: any;
+    id?: number;
     params?: any;
     _meta?: {
         data: any;
     };
 };
-declare type DataTypeBaseFromRequestType<R> = R extends {
+declare type DataTypeBaseFromRequestType<R extends RequestBase, ID> = R extends {
     _meta?: {
         data: infer DataType;
     };
-} ? DataType : never;
-export declare type DataTypeFromRequest<Req extends RequestBase, R extends RequestBase> = ValidateDataTypeExtraFileds<DataTypeFromQuery<DataTypeBaseFromRequestType<Req>, R['query']>>;
+} ? (ID extends number ? ([DataType, R['params']] extends [(infer DT)[], {
+    ids: number[];
+} | undefined] ? DT : never) : DataType) : never;
+export declare type DataTypeFromRequest<Req extends RequestBase, R extends RequestBase> = ValidateDataTypeExtraFileds<DataTypeFromQuery<DataTypeBaseFromRequestType<Req, R['id']>, R['query']>>;
 export {};

--- a/lib/ar_sync/type_script.rb
+++ b/lib/ar_sync/type_script.rb
@@ -78,7 +78,7 @@ module ArSync::TypeScript
     <<~CODE
       import { TypeRequest, ApiNameRequests } from './types'
       import { DataTypeFromRequest } from 'ar_sync/core/DataType'
-      import { useArSyncModel as useArSyncModelBase, useArSyncFetch as useArSyncFetchBase } from 'ar_sync/hooks'
+      import { useArSyncModel as useArSyncModelBase, useArSyncFetch as useArSyncFetchBase } from 'ar_sync/core/hooks'
       export function useArSyncModel<R extends TypeRequest>(request: R | null) {
         return useArSyncModelBase<DataTypeFromRequest<ApiNameRequests[R['api']], R>>(request)
       }

--- a/src/core/ArSyncStore.ts
+++ b/src/core/ArSyncStore.ts
@@ -132,7 +132,7 @@ class ArSyncContainerBase {
   static _load({ api, id, params, query }, root) {
     const parsedQuery = ArSyncRecord.parseQuery(query)
     if (id) {
-      return ModelBatchRequest.fetch(api, query, id).then(data => new ArSyncRecord(parsedQuery, data[0], null, root))
+      return ModelBatchRequest.fetch(api, query, id).then(data => new ArSyncRecord(parsedQuery, data, null, root))
     } else {
       const request = { api, query, params }
       return ArSyncAPI.syncFetch(request).then((response: any) => {

--- a/src/core/DataType.ts
+++ b/src/core/DataType.ts
@@ -73,8 +73,14 @@ type _ValidateDataTypeExtraFileds<Extra, Type> = SelectString<Values<Extra>> ext
   : { error: { extraFields: SelectString<Values<Extra>> } }
 type ValidateDataTypeExtraFileds<Type> = _ValidateDataTypeExtraFileds<CollectExtraFields<Type, []>, Type>
 
-type RequestBase = { api: string; query: any; params?: any; _meta?: { data: any } }
-type DataTypeBaseFromRequestType<R> = R extends { _meta?: { data: infer DataType } } ? DataType : never
+type RequestBase = { api: string; query: any; id?: number; params?: any; _meta?: { data: any } }
+type DataTypeBaseFromRequestType<R extends RequestBase, ID> = R extends { _meta?: { data: infer DataType } }
+  ? (
+      ID extends number
+      ? ([DataType, R['params']] extends [(infer DT)[], { ids: number[] } | undefined] ? DT : never)
+      : DataType
+    )
+  : never
 export type DataTypeFromRequest<Req extends RequestBase, R extends RequestBase> = ValidateDataTypeExtraFileds<
-  DataTypeFromQuery<DataTypeBaseFromRequestType<Req>, R['query']>
+  DataTypeFromQuery<DataTypeBaseFromRequestType<Req, R['id']>, R['query']>
 >

--- a/test/sync_test.rb
+++ b/test/sync_test.rb
@@ -235,3 +235,20 @@ tap do # root array field test
   post1.update title: title2
   runner.assert_script 'postsModel.data[0].title', to_be: title2
 end
+
+tap do # model load from id
+  post1 = Post.first
+  post2 = Post.second
+  runner.eval_script <<~JAVASCRIPT
+    global.p1 = new ArSyncModel({ api: 'Post', id: #{post1.id}, query: 'title' })
+    global.p2 = new ArSyncModel({ api: 'Post', id: #{post2.id}, query: 'title' })
+  JAVASCRIPT
+  runner.assert_script 'p1.data && p2.data'
+  runner.assert_script '[p1.data.title, p2.data.title]', to_be: [post1.title, post2.title]
+  p1title = "P1#{rand}"
+  post1.update title: p1title
+  runner.assert_script '[p1.data.title, p2.data.title]', to_be: [p1title, post2.title]
+  p2title = "P2#{rand}"
+  post2.update title: p2title
+  runner.assert_script '[p1.data.title, p2.data.title]', to_be: [p1title, p2title]
+end

--- a/test/ts_test.rb
+++ b/test/ts_test.rb
@@ -7,6 +7,7 @@ class TsTest < Minitest::Test
     include ArSerializer::Serializable
     serializer_field :currentUser, type: User
     serializer_field :users, type: [User]
+    serializer_field 'User', type: [User], params_type: { ids: [:int] }
   end
 
   def test_ts_type_generate

--- a/test/type_test.ts
+++ b/test/type_test.ts
@@ -41,6 +41,8 @@ const data14 = new ArSyncModel({ api: 'currentUser', query: { posts: { params: {
 data14.posts[0].title
 const data15 = new ArSyncModel({ api: 'currentUser', query: { posts: ['id', 'title'] } } as const).data!
 data15.posts[0].title
+const data16 = new ArSyncModel({ api: 'User', id: 1, query: 'name' }).data!
+data16.name
 
 const model = new ArSyncModel({ api: 'currentUser', query: { posts: ['id', 'title'] } } as const)
 let digId = model.dig(['posts', 0, 'id'] as const)


### PR DESCRIPTION
#74 
`new ArSyncModel({ api: 'User', params: { ids: [1,2,3] }, query })` は元から使えた
`new ArSyncModel({ api: 'User', id: 1, query })` はなぜか用意されてたけどバグってたので直した、型がつくようにした(多数同時に作ってもbatchで`ids: [1,2,3]`にまとめてリクエストなげる)


