### PR TITLE
typescript 3.7.2にあげた、型のバグ直した

### DIFF
--- a/core/ArSyncApi.d.ts
+++ b/core/ArSyncApi.d.ts
@@ -2,7 +2,7 @@ declare function apiBatchFetch(endpoint: string, requests: object[]): Promise<an
 declare const ArSyncApi: {
     domain: string | null;
     _batchFetch: typeof apiBatchFetch;
-    fetch: (request: object) => Promise<{}>;
-    syncFetch: (request: object) => Promise<{}>;
+    fetch: (request: object) => Promise<unknown>;
+    syncFetch: (request: object) => Promise<unknown>;
 };
 export default ArSyncApi;

--- a/core/ArSyncApi.js
+++ b/core/ArSyncApi.js
@@ -53,7 +53,7 @@ class ApiFetcher {
                             }
                             else {
                                 const error = result.error || { type: 'Unknown Error' };
-                                callback.reject(Object.assign({}, error, { retry: false }));
+                                callback.reject(Object.assign(Object.assign({}, error), { retry: false }));
                             }
                         }
                     }

--- a/core/ArSyncModel.d.ts
+++ b/core/ArSyncModel.d.ts
@@ -61,6 +61,6 @@ export default class ArSyncModel<T> {
     static _detach(ref: any): void;
     private static _attach;
     static setConnectionAdapter(adapter: ConnectionAdapter): void;
-    static waitForLoad(...models: ArSyncModel<{}>[]): Promise<{}>;
+    static waitForLoad(...models: ArSyncModel<{}>[]): Promise<unknown>;
 }
 export {};

--- a/core/ArSyncModel.js
+++ b/core/ArSyncModel.js
@@ -128,6 +128,6 @@ class ArSyncModel {
         });
     }
 }
+exports.default = ArSyncModel;
 ArSyncModel._cache = {};
 ArSyncModel.cacheTimeout = 10 * 1000;
-exports.default = ArSyncModel;

--- a/core/DataType.d.ts
+++ b/core/DataType.d.ts
@@ -6,7 +6,8 @@ declare type RecordType = {
 declare type Values<T> = T extends {
     [K in keyof T]: infer U;
 } ? U : never;
-declare type DataTypeExtractField<BaseType, Key extends keyof BaseType> = BaseType[Key] extends RecordType ? (null extends BaseType[Key] ? {} | null : {}) : BaseType[Key] extends RecordType[] ? {}[] : BaseType[Key];
+declare type AddNullable<Test, Type> = null extends Test ? Type | null : Type;
+declare type DataTypeExtractField<BaseType, Key extends keyof BaseType> = Exclude<BaseType[Key], null> extends RecordType ? AddNullable<BaseType[Key], {}> : BaseType[Key] extends RecordType[] ? {}[] : BaseType[Key];
 declare type DataTypeExtractFieldsFromQuery<BaseType, Fields> = '*' extends Fields ? {
     [key in Exclude<keyof BaseType, '_meta'>]: DataTypeExtractField<BaseType, key>;
 } : {
@@ -16,16 +17,16 @@ interface ExtraFieldErrorType {
     error: 'extraFieldError';
 }
 declare type DataTypeExtractFromQueryHash<BaseType, QueryType> = '*' extends keyof QueryType ? {
-    [key in Exclude<(keyof BaseType) | (keyof QueryType), '_meta' | '_params' | '*'>]: (key extends keyof BaseType ? (key extends keyof QueryType ? (QueryType[key] extends true ? DataTypeExtractField<BaseType, key> : DataTypeFromQuery<BaseType[key] & {}, QueryType[key]>) : DataTypeExtractField<BaseType, key>) : ExtraFieldErrorType);
+    [key in Exclude<(keyof BaseType) | (keyof QueryType), '_meta' | '_params' | '*'>]: (key extends keyof BaseType ? (key extends keyof QueryType ? (QueryType[key] extends true ? DataTypeExtractField<BaseType, key> : AddNullable<BaseType[key], DataTypeFromQuery<BaseType[key] & {}, QueryType[key]>>) : DataTypeExtractField<BaseType, key>) : ExtraFieldErrorType);
 } : {
-    [key in keyof QueryType]: (key extends keyof BaseType ? (QueryType[key] extends true ? DataTypeExtractField<BaseType, key> : DataTypeFromQuery<BaseType[key] & {}, QueryType[key]>) : ExtraFieldErrorType);
+    [key in keyof QueryType]: (key extends keyof BaseType ? (QueryType[key] extends true ? DataTypeExtractField<BaseType, key> : AddNullable<BaseType[key], DataTypeFromQuery<BaseType[key] & {}, QueryType[key]>>) : ExtraFieldErrorType);
 };
 declare type _DataTypeFromQuery<BaseType, QueryType> = QueryType extends keyof BaseType | '*' ? DataTypeExtractFieldsFromQuery<BaseType, QueryType> : QueryType extends Readonly<(keyof BaseType | '*')[]> ? DataTypeExtractFieldsFromQuery<BaseType, Values<QueryType>> : QueryType extends {
     as: string;
 } ? {
     error: 'type for alias field is not supported';
 } | undefined : DataTypeExtractFromQueryHash<BaseType, QueryType>;
-export declare type DataTypeFromQuery<BaseType, QueryType> = BaseType extends any[] ? CheckAttributesField<BaseType[0], QueryType>[] : null extends BaseType ? CheckAttributesField<BaseType & {}, QueryType> | null : CheckAttributesField<BaseType & {}, QueryType>;
+export declare type DataTypeFromQuery<BaseType, QueryType> = BaseType extends any[] ? CheckAttributesField<BaseType[0], QueryType>[] : AddNullable<BaseType, CheckAttributesField<BaseType & {}, QueryType>>;
 declare type CheckAttributesField<P, Q> = Q extends {
     attributes: infer R;
 } ? _DataTypeFromQuery<P, R> : _DataTypeFromQuery<P, Q>;

--- a/core/DataType.d.ts
+++ b/core/DataType.d.ts
@@ -32,7 +32,7 @@ declare type CheckAttributesField<P, Q> = Q extends {
 declare type IsAnyCompareLeftType = {
     __any: never;
 };
-declare type CollectExtraFields<Type, Path> = IsAnyCompareLeftType extends Type ? null : Type extends ExtraFieldErrorType ? Path : Type extends (infer R)[] ? _CollectExtraFields<R> : _CollectExtraFields<Type>;
+declare type CollectExtraFields<Type, Path> = Exclude<IsAnyCompareLeftType extends Type ? null : Type extends ExtraFieldErrorType ? Path : Type extends (infer R)[] ? _CollectExtraFields<R> : _CollectExtraFields<Type>, null>;
 declare type _CollectExtraFields<Type> = Type extends object ? (keyof (Type) extends never ? null : Values<{
     [key in keyof Type]: CollectExtraFields<Type[key], [key]>;
 }>) : null;

--- a/core/hooks.d.ts
+++ b/core/hooks.d.ts
@@ -1,12 +1,12 @@
 declare let useState: <T>(t: T | (() => T)) => [T, (t: T | ((t: T) => T)) => void];
 declare let useEffect: (f: (() => void) | (() => (() => void)), deps: any[]) => void;
 declare let useMemo: <T>(f: () => T, deps: any[]) => T;
-declare type SetHooksParams = {
+declare type InitializeHooksParams = {
     useState: typeof useState;
     useEffect: typeof useEffect;
     useMemo: typeof useMemo;
 };
-export declare function setHooks(hooks: SetHooksParams): void;
+export declare function initializeHooks(hooks: InitializeHooksParams): void;
 interface ModelStatus {
     complete: boolean;
     notfound?: boolean;

--- a/core/hooks.js
+++ b/core/hooks.js
@@ -5,15 +5,15 @@ const ArSyncModel_1 = require("./ArSyncModel");
 let useState;
 let useEffect;
 let useMemo;
-function setHooks(hooks) {
+function initializeHooks(hooks) {
     useState = hooks.useState;
     useEffect = hooks.useEffect;
     useMemo = hooks.useMemo;
 }
-exports.setHooks = setHooks;
+exports.initializeHooks = initializeHooks;
 function checkHooks() {
     if (!useState)
-        throw 'uninitialized. needs `setHooks({ useState, useEffect, useMemo })`';
+        throw 'uninitialized. needs `initializeHooks({ useState, useEffect, useMemo })`';
 }
 const initialResult = [null, { complete: false, notfound: undefined, connected: true }];
 function useArSyncModel(request) {

--- a/lib/ar_sync/rails.rb
+++ b/lib/ar_sync/rails.rb
@@ -90,10 +90,11 @@ module ArSync
       responses = params[:requests].map do |request|
         begin
           api_name = request[:api]
-          info = schema.class._serializer_field_info api_name
+          sch = schema
+          info = sch.class._serializer_field_info api_name
           raise ArSync::ApiNotFound, "#{type.to_s.capitalize} API named `#{api_name}` not configured" unless info
           api_params = (request[:params].as_json || {}).transform_keys(&:to_sym)
-          model = instance_exec(current_user, api_params, &info.data_block)
+          model = sch.instance_exec(current_user, api_params, &info.data_block)
           { data: yield(model, current_user, request[:query].as_json) }
         rescue StandardError => e
           { error: handle_exception(e) }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1078,9 +1078,9 @@
       }
     },
     "typescript": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
+      "integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==",
       "dev": true
     },
     "uri-js": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "actioncable": "^5.2.0",
     "@types/actioncable": "^5.2.0",
     "eslint": "^5.16.0",
-    "typescript": "^3.4.5",
+    "typescript": "3.7.2",
     "@typescript-eslint/eslint-plugin": "^1.6.0",
     "@typescript-eslint/parser": "^1.6.0"
   }

--- a/src/core/DataType.ts
+++ b/src/core/DataType.ts
@@ -1,6 +1,6 @@
 type RecordType = { _meta?: { query: any } }
 type Values<T> = T extends { [K in keyof T]: infer U } ? U : never
-type DataTypeExtractField<BaseType, Key extends keyof BaseType> = BaseType[Key] extends RecordType
+type DataTypeExtractField<BaseType, Key extends keyof BaseType> = Exclude<BaseType[Key], null> extends RecordType
   ? (null extends BaseType[Key] ? {} | null : {})
   : BaseType[Key] extends RecordType[]
   ? {}[]

--- a/src/core/DataType.ts
+++ b/src/core/DataType.ts
@@ -1,7 +1,8 @@
 type RecordType = { _meta?: { query: any } }
 type Values<T> = T extends { [K in keyof T]: infer U } ? U : never
+type AddNullable<Test, Type> = null extends Test ? Type | null : Type
 type DataTypeExtractField<BaseType, Key extends keyof BaseType> = Exclude<BaseType[Key], null> extends RecordType
-  ? (null extends BaseType[Key] ? {} | null : {})
+  ? AddNullable<BaseType[Key], {}>
   : BaseType[Key] extends RecordType[]
   ? {}[]
   : BaseType[Key]
@@ -20,7 +21,7 @@ type DataTypeExtractFromQueryHash<BaseType, QueryType> = '*' extends keyof Query
         ? (key extends keyof QueryType
             ? (QueryType[key] extends true
                 ? DataTypeExtractField<BaseType, key>
-                : DataTypeFromQuery<BaseType[key] & {}, QueryType[key]>)
+                : AddNullable<BaseType[key], DataTypeFromQuery<BaseType[key] & {}, QueryType[key]>>)
             : DataTypeExtractField<BaseType, key>)
         : ExtraFieldErrorType)
     }
@@ -28,7 +29,7 @@ type DataTypeExtractFromQueryHash<BaseType, QueryType> = '*' extends keyof Query
       [key in keyof QueryType]: (key extends keyof BaseType
         ? (QueryType[key] extends true
             ? DataTypeExtractField<BaseType, key>
-            : DataTypeFromQuery<BaseType[key] & {}, QueryType[key]>)
+            : AddNullable<BaseType[key], DataTypeFromQuery<BaseType[key] & {}, QueryType[key]>>)
         : ExtraFieldErrorType)
     }
 
@@ -42,9 +43,7 @@ type _DataTypeFromQuery<BaseType, QueryType> = QueryType extends keyof BaseType 
 
 export type DataTypeFromQuery<BaseType, QueryType> = BaseType extends any[]
   ? CheckAttributesField<BaseType[0], QueryType>[]
-  : null extends BaseType
-  ? CheckAttributesField<BaseType & {}, QueryType> | null
-  : CheckAttributesField<BaseType & {}, QueryType>
+  : AddNullable<BaseType, CheckAttributesField<BaseType & {}, QueryType>>
 
 type CheckAttributesField<P, Q> = Q extends { attributes: infer R }
   ? _DataTypeFromQuery<P, R>

--- a/src/core/DataType.ts
+++ b/src/core/DataType.ts
@@ -52,13 +52,14 @@ type CheckAttributesField<P, Q> = Q extends { attributes: infer R }
 
 type IsAnyCompareLeftType = { __any: never }
 
-type CollectExtraFields<Type, Path> = IsAnyCompareLeftType extends Type
+type CollectExtraFields<Type, Path> = Exclude<
+  IsAnyCompareLeftType extends Type
   ? null
   : Type extends ExtraFieldErrorType
   ? Path
   : Type extends (infer R)[]
   ? _CollectExtraFields<R>
-  : _CollectExtraFields<Type>
+  : _CollectExtraFields<Type>, null>
 
 type _CollectExtraFields<Type> = Type extends object
   ? (keyof (Type) extends never

--- a/src/core/hooks.ts
+++ b/src/core/hooks.ts
@@ -4,18 +4,18 @@ import ArSyncModel from './ArSyncModel'
 let useState: <T>(t: T | (() => T)) => [T, (t: T | ((t: T) => T)) => void]
 let useEffect: (f: (() => void) | (() => (() => void)), deps: any[]) => void
 let useMemo: <T>(f: () => T, deps: any[]) => T
-type SetHooksParams = {
+type InitializeHooksParams = {
   useState: typeof useState
   useEffect: typeof useEffect
   useMemo: typeof useMemo
 }
-export function setHooks(hooks: SetHooksParams) {
+export function initializeHooks(hooks: InitializeHooksParams) {
   useState = hooks.useState
   useEffect = hooks.useEffect
   useMemo = hooks.useMemo
 }
 function checkHooks() {
-  if (!useState) throw 'uninitialized. needs `setHooks({ useState, useEffect, useMemo })`'
+  if (!useState) throw 'uninitialized. needs `initializeHooks({ useState, useEffect, useMemo })`'
 }
 
 interface ModelStatus { complete: boolean; notfound?: boolean; connected: boolean }

--- a/test/model.rb
+++ b/test/model.rb
@@ -11,6 +11,7 @@ class User < BaseRecord
   has_many :posts, dependent: :destroy
   sync_has_data :id, :name
   sync_has_many :posts
+  sync_has_one(:postOrNull, type: ->{ [Post, nil] }) { nil }
 end
 
 class Post < BaseRecord

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "strict": true,
+  },
+  "include": ["."],
+}

--- a/test/type_test.ts
+++ b/test/type_test.ts
@@ -25,7 +25,7 @@ isOK<IsEqual<typeof data1, { id: number }>>()
 const data2 = new ArSyncModel({ api: 'currentUser', query: ['id', 'name'] }).data!
 isOK<IsEqual<typeof data2, { id: number; name: string | null }>>()
 const data3 = new ArSyncModel({ api: 'currentUser', query: '*' }).data!
-isOK<IsEqual<typeof data3, { id: number; name: string | null; sync_keys: string[]; posts: {}[] }>>()
+isOK<IsEqual<typeof data3, { id: number; name: string | null; sync_keys: string[]; posts: {}[]; postOrNull: {} | null }>>()
 const data4 = new ArSyncModel({ api: 'currentUser',  query: { posts: 'id' } }).data!
 isOK<IsEqual<typeof data4, { posts: { id: number }[] }>>()
 const data5 = new ArSyncModel({ api: 'currentUser', query: { posts: '*' } }).data!

--- a/test/type_test.ts
+++ b/test/type_test.ts
@@ -8,7 +8,7 @@ type IsEqual<T, U> = [T, U] extends [U, T] ? true : false
 function isOK<T extends true>(): T | undefined { return }
 type IsStrictMode = string | null extends string ? false : true
 type TypeIncludes<T extends {}, U extends {}> = IsEqual<Pick<T, keyof T & keyof U>, U>
-type HasExtraField<T extends { error: { extraFields: any } }, U> = IsEqual<T['error']['extraFields'], U>
+type HasExtraField<T extends { error: { extraFields: any } } | null, U> = IsEqual<Exclude<T, null>['error']['extraFields'], U>
 isOK<IsStrictMode>()
 
 const [hooksData1] = useArSyncModel({ api: 'currentUser', query: 'id' })

--- a/test/type_test.ts
+++ b/test/type_test.ts
@@ -53,6 +53,12 @@ const data15 = new ArSyncModel({ api: 'currentUser', query: { posts: ['id', 'tit
 isOK<IsEqual<(typeof data15.posts)[0], { id: number; title: string | null }>>()
 const data16 = new ArSyncModel({ api: 'User', id: 1, query: 'name' }).data!
 isOK<IsEqual<typeof data16, { name: string | null }>>()
+const data17 = new ArSyncModel({ api: 'currentUser', query: 'postOrNull' }).data!
+isOK<IsEqual<typeof data17, { postOrNull: {} | null }>>()
+const data18 = new ArSyncModel({ api: 'currentUser', query: { postOrNull: 'title' } }).data!
+isOK<IsEqual<typeof data18, { postOrNull: { title: string | null } | null }>>()
+const data19 = new ArSyncModel({ api: 'currentUser', query: { '*': true, postOrNull: 'title' } }).data!
+isOK<TypeIncludes<typeof data19, { postOrNull: { title: string | null } | null }>>()
 
 const model = new ArSyncModel({ api: 'currentUser', query: { posts: ['id', 'title'] } } as const)
 let digId = model.dig(['posts', 0, 'id'] as const)

--- a/test/type_test.ts
+++ b/test/type_test.ts
@@ -4,53 +4,58 @@ import ActionCableAdapter from '../src/core/ActionCableAdapter'
 import * as ActionCable from 'actioncable'
 ArSyncModel.setConnectionAdapter(new ActionCableAdapter(ActionCable))
 
+type IsEqual<T, U> = [T, U] extends [U, T] ? true : false
+function isOK<T extends true>(): T | undefined { return }
+type IsStrictMode = string | null extends string ? false : true
+type TypeIncludes<T extends {}, U extends {}> = IsEqual<Pick<T, keyof T & keyof U>, U>
+type HasExtraField<T extends { error: { extraFields: any } }, U> = IsEqual<T['error']['extraFields'], U>
+isOK<IsStrictMode>()
+
 const [hooksData1] = useArSyncModel({ api: 'currentUser', query: 'id' })
-hooksData1!.id
+isOK<IsEqual<typeof hooksData1, { id: number } | null>>()
 const [hooksData2] = useArSyncModel({ api: 'currentUser', query: { '*': true, foo: true } })
-hooksData2!.error.extraFields = 'foo'
+isOK<HasExtraField<typeof hooksData2, 'foo'>>()
 const [hooksData3] = useArSyncFetch({ api: 'currentUser', query: 'id' })
-hooksData3!.id
+isOK<IsEqual<typeof hooksData3, { id: number } | null>>()
 const [hooksData4] = useArSyncFetch({ api: 'currentUser', query: { '*': true, foo: true } })
-hooksData4!.error.extraFields = 'foo'
+isOK<HasExtraField<typeof hooksData4, 'foo'>>()
 
 const data1 = new ArSyncModel({ api: 'currentUser', query: 'id' }).data!
-data1.id
+isOK<IsEqual<typeof data1, { id: number }>>()
 const data2 = new ArSyncModel({ api: 'currentUser', query: ['id', 'name'] }).data!
-data2.id; data2.name
+isOK<IsEqual<typeof data2, { id: number; name: string | null }>>()
 const data3 = new ArSyncModel({ api: 'currentUser', query: '*' }).data!
-data3.id; data3.name; data3.posts
+isOK<IsEqual<typeof data3, { id: number; name: string | null; sync_keys: string[]; posts: {}[] }>>()
 const data4 = new ArSyncModel({ api: 'currentUser',  query: { posts: 'id' } }).data!
-data4.posts[0].id
+isOK<IsEqual<typeof data4, { posts: { id: number }[] }>>()
 const data5 = new ArSyncModel({ api: 'currentUser', query: { posts: '*' } }).data!
 data5.posts[0].id; data5.posts[0].user; data5.posts[0].body
+isOK<TypeIncludes<typeof data5.posts[0], { body: string | null, comments: {}[] }>>()
 const data6 = new ArSyncModel({ api: 'currentUser', query: { posts: { '*': true, comments: 'user' } } }).data!
-data6.posts[0].id; data6.posts[0].user; data6.posts[0].comments[0].user
+isOK<TypeIncludes<typeof data6.posts[0], { user: {}, comments: { user: {} }[] }>>()
 const data7 = new ArSyncModel({ api: 'currentUser', query: { name: true, poosts: true } }).data!
-data7.error.extraFields = 'poosts'
+isOK<HasExtraField<typeof data7, 'poosts'>>()
 const data8 = new ArSyncModel({ api: 'currentUser', query: { posts: { id: true, commmments: true, titllle: true } } }).data!
-data8.error.extraFields = 'commmments'
-data8.error.extraFields = 'titllle'
+isOK<HasExtraField<typeof data8, 'commmments' | 'titllle'>>()
 const data9 = new ArSyncModel({ api: 'currentUser', query: { '*': true, posts: { id: true, commmments: true } } }).data!
-data9.error.extraFields = 'commmments'
+isOK<HasExtraField<typeof data9, 'commmments'>>()
 const data10 = new ArSyncModel({ api: 'users', query: { '*': true, posts: { id: true, comments: '*' } } }).data!
-data10[0].posts[0].comments[0].id
+isOK<TypeIncludes<(typeof data10)[0]['posts'][0]['comments'][0], { id: number; body: string | null }>>()
 const data11 = new ArSyncModel({ api: 'users', query: { '*': true, posts: { id: true, comments: '*', commmments: true } } }).data!
-data11.error.extraFields = 'commmments'
+isOK<HasExtraField<typeof data11, 'commmments'>>()
 const data12 = new ArSyncModel({ api: 'currentUser', query: { posts: { params: { limit: 4 }, attributes: 'title' } } }).data!
-data12.posts[0].title
+isOK<IsEqual<(typeof data12.posts)[0], { title: string | null }>>()
 const data13 = new ArSyncModel({ api: 'currentUser', query: { posts: { params: { limit: 4 }, attributes: ['id', 'title'] } } }).data!
-data13.posts[0].title
+isOK<IsEqual<(typeof data13.posts)[0], { id: number; title: string | null }>>()
 const data14 = new ArSyncModel({ api: 'currentUser', query: { posts: { params: { limit: 4 }, attributes: { id: true, title: true } } } }).data!
-data14.posts[0].title
+isOK<IsEqual<(typeof data14.posts)[0], { id: number; title: string | null }>>()
 const data15 = new ArSyncModel({ api: 'currentUser', query: { posts: ['id', 'title'] } } as const).data!
-data15.posts[0].title
+isOK<IsEqual<(typeof data15.posts)[0], { id: number; title: string | null }>>()
 const data16 = new ArSyncModel({ api: 'User', id: 1, query: 'name' }).data!
-data16.name
+isOK<IsEqual<typeof data16, { name: string | null }>>()
 
 const model = new ArSyncModel({ api: 'currentUser', query: { posts: ['id', 'title'] } } as const)
 let digId = model.dig(['posts', 0, 'id'] as const)
+isOK<IsEqual<typeof digId, number | null | undefined>>()
 let digTitle = model.dig(['posts', 0, 'title'] as const)
-digId = 1
-digTitle = 'title'
-digId = digTitle = undefined
-digId = digTitle = null
+isOK<IsEqual<typeof digTitle, string | null | undefined>>()


### PR DESCRIPTION
型のテスト 厳密に比較するようにした
extrafield抜き出しがtsバージョンあげたら動かなくなってたのを直した(今までnullが含まれなかった型にnullが入ってきてた。Exclude<X, null>追加)
has_one/belongs_toなfieldがnullableだった時の型が色々おかしかったのを直した(inifniteになったり、正しくない型を返したり)