### PR TITLE
Before mutation compare fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,39 +8,39 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.2.3)
-      activesupport (= 5.2.3)
-    activerecord (5.2.3)
-      activemodel (= 5.2.3)
-      activesupport (= 5.2.3)
-      arel (>= 9.0)
+    activemodel (6.0.2.1)
+      activesupport (= 6.0.2.1)
+    activerecord (6.0.2.1)
+      activemodel (= 6.0.2.1)
+      activesupport (= 6.0.2.1)
     activerecord-import (1.0.2)
       activerecord (>= 3.2)
-    activesupport (5.2.3)
+    activesupport (6.0.2.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+      zeitwerk (~> 2.2)
     ar_serializer (1.1.0)
       activerecord
       top_n_loader
-    arel (9.0.0)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
-    i18n (1.6.0)
+    i18n (1.7.0)
       concurrent-ruby (~> 1.0)
     method_source (0.9.2)
-    minitest (5.11.3)
+    minitest (5.13.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     rake (12.3.2)
-    sqlite3 (1.3.13)
+    sqlite3 (1.4.2)
     thread_safe (0.3.6)
     top_n_loader (1.0.1)
       activerecord
-    tzinfo (1.2.5)
+    tzinfo (1.2.6)
       thread_safe (~> 0.1)
+    zeitwerk (2.2.2)
 
 PLATFORMS
   ruby

--- a/lib/ar_sync/class_methods.rb
+++ b/lib/ar_sync/class_methods.rb
@@ -150,12 +150,6 @@ module ArSync::ModelBase::ClassMethods
       @_sync_belongs_to_info_before_mutation ||= _sync_current_belongs_to_info
     end
 
-    before_save on: :create do
-      @_sync_parents_info_before_mutation ||= {}
-      @_sync_watch_values_before_mutation ||= {}
-      @_sync_belongs_to_info_before_mutation ||= {}
-    end
-
     %i[create update destroy].each do |action|
       after_commit on: action do
         next if ArSync.skip_notification?

--- a/lib/ar_sync/instance_methods.rb
+++ b/lib/ar_sync/instance_methods.rb
@@ -65,11 +65,13 @@ module ArSync::ModelBase::InstanceMethods
       parents_was = parents.map { nil }
     elsif action == :destroy
       parents_was = _sync_parents_info_before_mutation
+      return unless parents_was
       parents = parents_was.map { nil }
     else
       parents_was = _sync_parents_info_before_mutation
+      return unless parents_was
       parents = _sync_current_parents_info
-      column_values_was = _sync_watch_values_before_mutation
+      column_values_was = _sync_watch_values_before_mutation || {}
       column_values = _sync_current_watch_values
     end
     parents_was.zip(parents).each do |(parent_was, info_was), (parent, info)|
@@ -109,6 +111,7 @@ module ArSync::ModelBase::InstanceMethods
 
   def _sync_notify_self
     belongs_was = _sync_belongs_to_info_before_mutation
+    return unless belongs_was
     belongs = _sync_current_belongs_to_info
     belongs.each do |name, info|
       next if belongs_was[name] == info

--- a/test/sync_test.rb
+++ b/test/sync_test.rb
@@ -19,6 +19,11 @@ end
 user = User.second
 runner = TestRunner.new Schema.new, user
 
+# _sync_xxx_before_mutation can be nil
+post = Post.last
+post.update title: post.title + '!'
+post.save
+
 runner.eval_script <<~JAVASCRIPT
   global.userModel = new ArSyncModel({
     api: 'currentUser',


### PR DESCRIPTION
_xxx_before_mutationがnilのことがある(nilにリセットすることがある、それは正しい)
が、その時にparentなどが変化したかどうかのチェックが正しく動かなかった
それと関連した不要なbefore_saveもあったので消した
(`before_save on:` がactiverecord6で使えなくなってたのを対応しようと見てたらいろいろ見つけた)