### PR TITLE
Hooks immediate change

### DIFF
--- a/core/hooks.d.ts
+++ b/core/hooks.d.ts
@@ -1,10 +1,14 @@
 declare let useState: <T>(t: T | (() => T)) => [T, (t: T | ((t: T) => T)) => void];
 declare let useEffect: (f: (() => void) | (() => (() => void)), deps: any[]) => void;
 declare let useMemo: <T>(f: () => T, deps: any[]) => T;
+declare let useRef: <T>(value: T) => {
+    current: T;
+};
 declare type InitializeHooksParams = {
     useState: typeof useState;
     useEffect: typeof useEffect;
     useMemo: typeof useMemo;
+    useRef: typeof useRef;
 };
 export declare function initializeHooks(hooks: InitializeHooksParams): void;
 interface ModelStatus {

--- a/lib/ar_sync/type_script.rb
+++ b/lib/ar_sync/type_script.rb
@@ -82,11 +82,11 @@ module ArSync::TypeScript
 
   def self.generate_hooks_script
     <<~CODE
-      import { useState, useEffect, useMemo } from 'react'
+      import { useState, useEffect, useMemo, useRef } from 'react'
       import { TypeRequest } from './types'
       import DataTypeFromRequest from './DataTypeFromRequest'
       import { initializeHooks, useArSyncModel as useArSyncModelBase, useArSyncFetch as useArSyncFetchBase } from 'ar_sync/core/hooks'
-      initializeHooks({ useState, useEffect, useMemo })
+      initializeHooks({ useState, useEffect, useMemo, useRef })
       export function useArSyncModel<R extends TypeRequest>(request: R | null) {
         return useArSyncModelBase<DataTypeFromRequest<R>>(request)
       }

--- a/src/core/hooks.ts
+++ b/src/core/hooks.ts
@@ -68,7 +68,7 @@ const initialFetchState: FetchState<any> = { data: null, status: { complete: fal
 
 function extractParams(query: unknown, output: any[] = []): any[] {
   if (typeof(query) !== 'object' || query == null || Array.isArray(query)) return output
-  if ('params' in query) output.push((query as { params }).params)
+  if ('params' in query) output.push((query as { params: any }).params)
   for (const key in query) {
     extractParams(query[key], output)
   }
@@ -78,7 +78,11 @@ function extractParams(query: unknown, output: any[] = []): any[] {
 export function useArSyncFetch<T>(request: Request | null): DataStatusUpdate<T> {
   checkHooks()
   const [state, setState] = useState<FetchState<T>>(initialFetchState)
-  const requestString = useMemo(() => JSON.stringify(extractParams(request)), [request])
+  const query = request && request.query
+  const params = request && request.params
+  const requestString = useMemo(() => {
+    return JSON.stringify(extractParams(query, [params]))
+  }, [query, params])
   const prevRequestStringRef = useRef(requestString)
   const loader = useMemo(() => {
     let lastLoadId = 0

--- a/src/core/hooks.ts
+++ b/src/core/hooks.ts
@@ -4,18 +4,21 @@ import ArSyncModel from './ArSyncModel'
 let useState: <T>(t: T | (() => T)) => [T, (t: T | ((t: T) => T)) => void]
 let useEffect: (f: (() => void) | (() => (() => void)), deps: any[]) => void
 let useMemo: <T>(f: () => T, deps: any[]) => T
+let useRef: <T>(value: T) => { current: T }
 type InitializeHooksParams = {
   useState: typeof useState
   useEffect: typeof useEffect
   useMemo: typeof useMemo
+  useRef: typeof useRef
 }
 export function initializeHooks(hooks: InitializeHooksParams) {
   useState = hooks.useState
   useEffect = hooks.useEffect
   useMemo = hooks.useMemo
+  useRef = hooks.useRef
 }
 function checkHooks() {
-  if (!useState) throw 'uninitialized. needs `initializeHooks({ useState, useEffect, useMemo })`'
+  if (!useState) throw 'uninitialized. needs `initializeHooks({ useState, useEffect, useMemo, useRef })`'
 }
 
 interface ModelStatus { complete: boolean; notfound?: boolean; connected: boolean }
@@ -27,7 +30,9 @@ export function useArSyncModel<T>(request: Request | null): DataAndStatus<T> {
   checkHooks()
   const [result, setResult] = useState<DataAndStatus<T>>(initialResult)
   const requestString = JSON.stringify(request && request.params)
+  const prevRequestStringRef = useRef(requestString)
   useEffect(() => {
+    prevRequestStringRef.current = requestString
     if (!request) {
       setResult(initialResult)
       return () => {}
@@ -53,17 +58,28 @@ export function useArSyncModel<T>(request: Request | null): DataAndStatus<T> {
     model.subscribe('connection', update)
     return () => model.release()
   }, [requestString])
-  return result
+  return prevRequestStringRef.current === requestString ? result : initialResult
 }
 
 interface FetchStatus { complete: boolean; notfound?: boolean }
 type DataStatusUpdate<T> = [T | null, FetchStatus, () => void]
 type FetchState<T> = { data: T | null; status: FetchStatus }
 const initialFetchState: FetchState<any> = { data: null, status: { complete: false, notfound: undefined } }
+
+function extractParams(query: unknown, output: any[] = []): any[] {
+  if (typeof(query) !== 'object' || query == null || Array.isArray(query)) return output
+  if ('params' in query) output.push((query as { params }).params)
+  for (const key in query) {
+    extractParams(query[key], output)
+  }
+  return output
+}
+
 export function useArSyncFetch<T>(request: Request | null): DataStatusUpdate<T> {
   checkHooks()
   const [state, setState] = useState<FetchState<T>>(initialFetchState)
-  const requestString = JSON.stringify(request && request.params)
+  const requestString = useMemo(() => JSON.stringify(extractParams(request)), [request])
+  const prevRequestStringRef = useRef(requestString)
   const loader = useMemo(() => {
     let lastLoadId = 0
     let timer: null | number = null
@@ -102,9 +118,11 @@ export function useArSyncFetch<T>(request: Request | null): DataStatusUpdate<T> 
     return { update, cancel }
   }, [requestString])
   useEffect(() => {
+    prevRequestStringRef.current = requestString
     setState(initialFetchState)
     loader.update()
     return () => loader.cancel()
   }, [requestString])
-  return [state.data, state.status, loader.update]
+  const responseState = prevRequestStringRef.current === requestString ? state : initialFetchState
+  return [responseState.data, responseState.status, loader.update]
 }


### PR DESCRIPTION
hooksのparamsが変わった時、null(読み込み中)の前に一瞬古い値を返してしまう問題修正
```ts
const [post, status] = useArSyncModel({api: 'post', query: ['id', 'title'], params: { id }})
if (post && id != post.id) console.log('もうこれ起きない')
```

useArSyncFetchのみ、fieldへのparamsを変更したときもリロードする
```ts
const [post, status, reload] = useArSyncFetch({api:'post', query: { comments: { params: { order: { limit } }}}, params: { id })
useEffect(() => {
  setTimeout(() => setId(12), 1000) // ok
  setTimeout(() => setLimit(34), 2000) // 前は動かなかった
}, [])
```
毎回queryの中身全部チェックするようになったという意味で、それでパフォーマンス気になるなら
```ts
useArSyncFetch(useMemo(() => request, [deps]))
useArSyncFetch({ api, query: useMemo(() => query, [deps]), params })
```
と書ける(違うオブジェクトだった場合にのみquery中のparamsに差分が無いか見る)

