### PR TITLE
initialize_before_mutationがおかしかった

### DIFF
--- a/lib/ar_sync/class_methods.rb
+++ b/lib/ar_sync/class_methods.rb
@@ -119,11 +119,11 @@ module ArSync::ModelBase::ClassMethods
       end
     end
     def _write_attribute(attr_name, value)
-      _initialize_sync_info_before_mutation
+      _initialize_sync_info_before_mutation if self[attr_name] != value
       super attr_name, value
     end
     def write_attribute(attr_name, value)
-      _initialize_sync_info_before_mutation
+      _initialize_sync_info_before_mutation if self[attr_name] != value
       super attr_name, value
     end
   end

--- a/lib/ar_sync/class_methods.rb
+++ b/lib/ar_sync/class_methods.rb
@@ -112,10 +112,16 @@ module ArSync::ModelBase::ClassMethods
 
   module WriteHook
     def _initialize_sync_info_before_mutation
-      self.class.default_scoped.scoping do
-        @_sync_watch_values_before_mutation ||= _sync_current_watch_values
-        @_sync_parents_info_before_mutation ||= _sync_current_parents_info
-        @_sync_belongs_to_info_before_mutation ||= _sync_current_belongs_to_info
+      if new_record?
+        @_sync_watch_values_before_mutation ||= {}
+        @_sync_parents_info_before_mutation ||= {}
+        @_sync_belongs_to_info_before_mutation ||= {}
+      else
+        self.class.default_scoped.scoping do
+          @_sync_watch_values_before_mutation ||= _sync_current_watch_values
+          @_sync_parents_info_before_mutation ||= _sync_current_parents_info
+          @_sync_belongs_to_info_before_mutation ||= _sync_current_belongs_to_info
+        end
       end
     end
     def _write_attribute(attr_name, value)

--- a/lib/ar_sync/class_methods.rb
+++ b/lib/ar_sync/class_methods.rb
@@ -112,6 +112,7 @@ module ArSync::ModelBase::ClassMethods
 
   module WriteHook
     def _initialize_sync_info_before_mutation
+      return unless instance_variable_defined? '@_initialized'
       if new_record?
         @_sync_watch_values_before_mutation ||= {}
         @_sync_parents_info_before_mutation ||= {}
@@ -125,11 +126,11 @@ module ArSync::ModelBase::ClassMethods
       end
     end
     def _write_attribute(attr_name, value)
-      _initialize_sync_info_before_mutation if self[attr_name] != value
+      _initialize_sync_info_before_mutation
       super attr_name, value
     end
     def write_attribute(attr_name, value)
-      _initialize_sync_info_before_mutation if self[attr_name] != value
+      _initialize_sync_info_before_mutation
       super attr_name, value
     end
   end
@@ -148,6 +149,10 @@ module ArSync::ModelBase::ClassMethods
 
     _sync_define :defaults, namespace: :sync do |current_user|
       { sync_keys: ArSync.sync_keys(self, current_user) }
+    end
+
+    after_initialize do
+      @_initialized = true
     end
 
     before_destroy do


### PR DESCRIPTION
write_attributeをhookして、mutation前の状態を保存してる(`_sync_xxx_before_mutation`)が、
`Post.includes(:comments)` などを実行した時にinverse_of指定したcomment.postへの代入で誤発火してしまう問題があった。

initialize前(`after_initialize{@_initialized = true}`)のwrite_attributeは全部無視するように