### PR TITLE
subquery無しの時のバグとか修正

### DIFF
--- a/src/core/ArSyncStore.ts
+++ b/src/core/ArSyncStore.ts
@@ -472,11 +472,11 @@ class ArSyncCollection extends ArSyncContainerBase {
     const newData: any[] = []
     for (const subData of collection) {
       let model: ArSyncRecord | undefined = undefined
-      if (typeof(subData) === 'object' && subData && 'id' in subData) model = existings.get(subData.id)
+      if (typeof(subData) === 'object' && subData && 'sync_keys' in subData) model = existings.get(subData.id)
       let data = subData
       if (model) {
         model.replaceData(subData)
-      } else if (subData.id) {
+      } else if (subData.sync_keys) {
         model = new ArSyncRecord(this.query, subData, null, this.root)
         model.parentModel = this
         model.parentKey = subData.id

--- a/src/core/ArSyncStore.ts
+++ b/src/core/ArSyncStore.ts
@@ -231,6 +231,7 @@ class ArSyncRecord extends ArSyncContainerBase {
   id: number
   root
   query
+  queryAttributes
   data
   children: { [key: string]: ArSyncContainerBase | null }
   paths: string[]
@@ -240,6 +241,7 @@ class ArSyncRecord extends ArSyncContainerBase {
     this.root = root
     if (request) this.initForReload(request)
     this.query = query
+    this.queryAttributes = query.attributes || {}
     this.data = {}
     this.children = {}
     this.replaceData(data)
@@ -258,8 +260,8 @@ class ArSyncRecord extends ArSyncContainerBase {
       this.data.id = data.id
     }
     this.paths = []
-    for (const key in this.query.attributes) {
-      const subQuery = this.query.attributes[key]
+    for (const key in this.queryAttributes) {
+      const subQuery = this.queryAttributes[key]
       const aliasName = subQuery.as || key
       const subData = data[aliasName]
       const child = this.children[aliasName]
@@ -300,9 +302,9 @@ class ArSyncRecord extends ArSyncContainerBase {
         }
       }
     }
-    if (this.query.attributes['*']) {
+    if (this.queryAttributes['*']) {
       for (const key in data) {
-        if (!this.query.attributes[key] && this.data[key] !== data[key]) {
+        if (!this.queryAttributes[key] && this.data[key] !== data[key]) {
           this.mark()
           this.data[key] = data[key]
         }
@@ -312,7 +314,7 @@ class ArSyncRecord extends ArSyncContainerBase {
   }
   onNotify(notifyData: NotifyData, path?: string) {
     const { action, class_name: className, id } = notifyData
-    const query = path && this.query.attributes[path]
+    const query = path && this.queryAttributes[path]
     const aliasName = (query && query.as) || path;
     if (action === 'remove') {
       const child = this.children[aliasName]
@@ -359,7 +361,7 @@ class ArSyncRecord extends ArSyncContainerBase {
     }
   }
   patchQuery(key: string) {
-    const val = this.query.attributes[key]
+    const val = this.queryAttributes[key]
     if (!val) return
     let { attributes, as, params } = val
     if (attributes && Object.keys(val.attributes).length === 0) attributes = null
@@ -373,9 +375,9 @@ class ArSyncRecord extends ArSyncContainerBase {
   reloadQuery() {
     if (this.reloadQueryCache) return this.reloadQueryCache
     const reloadQuery = this.reloadQueryCache = { attributes: [] as any[] }
-    for (const key in this.query.attributes) {
+    for (const key in this.queryAttributes) {
       if (key === 'sync_keys') continue
-      const val = this.query.attributes[key]
+      const val = this.queryAttributes[key]
       if (!val || !val.attributes) {
         reloadQuery.attributes.push(key)
       } else if (!val.params && Object.keys(val.attributes).length === 0) {
@@ -386,7 +388,7 @@ class ArSyncRecord extends ArSyncContainerBase {
   }
   update(data) {
     for (const key in data) {
-      const subQuery = this.query.attributes[key]
+      const subQuery = this.queryAttributes[key]
       if (subQuery && subQuery.attributes && Object.keys(subQuery.attributes).length > 0) continue
       if (this.data[key] === data[key]) continue
       this.mark()
@@ -411,6 +413,7 @@ class ArSyncCollection extends ArSyncContainerBase {
   path: string
   order: { limit: number | null; key: string; mode: 'asc' | 'desc' } = { limit: null, mode: 'asc', key: 'id' }
   query
+  queryAttributes
   compactQuery
   data: any[]
   children: ArSyncRecord[]
@@ -420,6 +423,7 @@ class ArSyncCollection extends ArSyncContainerBase {
     this.root = root
     this.path = path
     this.query = query
+    this.queryAttributes = query.attributes || {}
     this.compactQuery = ArSyncRecord.compactQuery(query)
     if (request) this.initForReload(request)
     if (query.params && (query.params.order || query.params.limit)) {
@@ -442,7 +446,7 @@ class ArSyncCollection extends ArSyncContainerBase {
     }
     const limitNumber = (typeof limit === 'number') ? limit : null
     if (limitNumber !== null && key !== 'id') throw 'limit with custom order key is not supported'
-    const subQuery = this.query.attributes[key]
+    const subQuery = this.queryAttributes[key]
     this.aliasOrderKey = (subQuery && subQuery.as) || key
     this.order = { limit: limitNumber, mode, key }
   }

--- a/test/model.rb
+++ b/test/model.rb
@@ -12,6 +12,8 @@ class User < BaseRecord
   sync_has_data :id, :name
   sync_has_many :posts
   sync_has_one(:postOrNull, type: ->{ [Post, nil] }) { nil }
+  sync_has_data(:itemWithId) { { id: 1, value: 'data' } }
+  sync_has_data(:itemsWithId) { [{ id: 1, value: 'data' }] }
 end
 
 class Post < BaseRecord

--- a/test/sync_test.rb
+++ b/test/sync_test.rb
@@ -169,6 +169,17 @@ tap do # order test
   runner.eval_script 'postModel.release(); postModel = null'
 end
 
+tap do # no subquery test
+  runner.eval_script <<~JAVASCRIPT
+    global.noSubqueryTestModel = new ArSyncModel({
+      api: 'currentUser',
+      query: ['id', 'posts']
+    })
+  JAVASCRIPT
+  runner.assert_script 'noSubqueryTestModel.data'
+  runner.assert_script 'noSubqueryTestModel.data.posts[0].id >= 1'
+end
+
 tap do # wildcard update test
   runner.eval_script <<~JAVASCRIPT
     global.wildCardTestModel = new ArSyncModel({

--- a/test/sync_test.rb
+++ b/test/sync_test.rb
@@ -180,6 +180,18 @@ tap do # no subquery test
   runner.assert_script 'noSubqueryTestModel.data.posts[0].id >= 1'
 end
 
+tap do # object field test
+  runner.eval_script <<~JAVASCRIPT
+    global.objectFieldTestModel = new ArSyncModel({
+      api: 'currentUser',
+      query: ['itemWithId', 'itemsWithId']
+    })
+  JAVASCRIPT
+  runner.assert_script 'objectFieldTestModel.data'
+  runner.assert_script 'objectFieldTestModel.data.itemWithId', to_be: { 'id' => 1, 'value' => 'data' }
+  runner.assert_script 'objectFieldTestModel.data.itemsWithId', to_be: [{ 'id' => 1, 'value' => 'data' }]
+end
+
 tap do # wildcard update test
   runner.eval_script <<~JAVASCRIPT
     global.wildCardTestModel = new ArSyncModel({

--- a/test/type_test.ts
+++ b/test/type_test.ts
@@ -25,7 +25,7 @@ isOK<IsEqual<typeof data1, { id: number }>>()
 const data2 = new ArSyncModel({ api: 'currentUser', query: ['id', 'name'] }).data!
 isOK<IsEqual<typeof data2, { id: number; name: string | null }>>()
 const data3 = new ArSyncModel({ api: 'currentUser', query: '*' }).data!
-isOK<IsEqual<typeof data3, { id: number; name: string | null; sync_keys: string[]; posts: {}[]; postOrNull: {} | null }>>()
+isOK<IsEqual<typeof data3, { id: number; name: string | null; sync_keys: string[]; posts: {}[]; postOrNull: {} | null; itemWithId: any; itemsWithId: any }>>()
 const data4 = new ArSyncModel({ api: 'currentUser',  query: { posts: 'id' } }).data!
 isOK<IsEqual<typeof data4, { posts: { id: number }[] }>>()
 const data5 = new ArSyncModel({ api: 'currentUser', query: { posts: '*' } }).data!


### PR DESCRIPTION
#107 
query.attributesがないかもしれない対処
(`user: { comments: ['id'] }` `user: { comments: true }` はok `user: ['comments']` はだめ)
dataにidが含まれているかどうかでsync対象か判別してたのをやめた(sync_keys見ればそれでよかった)