### PR TITLE
fix model load from id when not found

### DIFF
--- a/core/ArSyncApi.js
+++ b/core/ArSyncApi.js
@@ -108,7 +108,7 @@ var ApiFetcher = /** @class */ (function () {
                         var callbacks = callbacksList[i];
                         for (var _i = 0, callbacks_1 = callbacks; _i < callbacks_1.length; _i++) {
                             var callback = callbacks_1[_i];
-                            if (result.data) {
+                            if (result.data !== undefined) {
                                 callback.resolve(result.data);
                             }
                             else {

--- a/core/ArSyncStore.js
+++ b/core/ArSyncStore.js
@@ -237,12 +237,19 @@ var ArSyncContainerBase = /** @class */ (function () {
         var parsedQuery = ArSyncRecord.parseQuery(query);
         var compactQuery = ArSyncRecord.compactQuery(parsedQuery);
         if (id) {
-            return modelBatchRequest.fetch(api, compactQuery, id).then(function (data) { return new ArSyncRecord(parsedQuery, data, null, root); });
+            return modelBatchRequest.fetch(api, compactQuery, id).then(function (data) {
+                if (!data)
+                    throw { retry: false };
+                return new ArSyncRecord(parsedQuery, data, null, root);
+            });
         }
         else {
             var request_1 = { api: api, query: compactQuery, params: params };
             return ArSyncApi_1.default.syncFetch(request_1).then(function (response) {
-                if (response.collection && response.order) {
+                if (!response) {
+                    throw { retry: false };
+                }
+                else if (response.collection && response.order) {
                     return new ArSyncCollection(response.sync_keys, 'collection', parsedQuery, response, request_1, root);
                 }
                 else if (response instanceof Array) {

--- a/src/core/ArSyncApi.ts
+++ b/src/core/ArSyncApi.ts
@@ -53,7 +53,7 @@ class ApiFetcher {
             const result = results[i]
             const callbacks = callbacksList[i]
             for (const callback of callbacks) {
-              if (result.data) {
+              if (result.data !== undefined) {
                 callback.resolve(result.data)
               } else {
                 const error = result.error || { type: 'Unknown Error' }

--- a/src/core/ArSyncStore.ts
+++ b/src/core/ArSyncStore.ts
@@ -190,11 +190,16 @@ class ArSyncContainerBase {
     const parsedQuery = ArSyncRecord.parseQuery(query)
     const compactQuery = ArSyncRecord.compactQuery(parsedQuery)
     if (id) {
-      return modelBatchRequest.fetch(api, compactQuery, id).then(data => new ArSyncRecord(parsedQuery, data, null, root))
+      return modelBatchRequest.fetch(api, compactQuery, id).then(data => {
+        if (!data) throw { retry: false }
+        return new ArSyncRecord(parsedQuery, data, null, root)
+      })
     } else {
       const request = { api, query: compactQuery, params }
       return ArSyncAPI.syncFetch(request).then((response: any) => {
-        if (response.collection && response.order) {
+        if (!response) {
+          throw { retry: false }
+        } else if (response.collection && response.order) {
           return new ArSyncCollection(response.sync_keys, 'collection', parsedQuery, response, request, root)
         } else if (response instanceof Array) {
           return new ArSyncCollection([], '', parsedQuery, response, request, root)

--- a/test/helper/test_runner.rb
+++ b/test/helper/test_runner.rb
@@ -26,8 +26,12 @@ class TestRunner
       info = @schema.class._serializer_field_info api_name
       api_params = (request['params'] || {}).transform_keys(&:to_sym)
       user = @current_user.reload
-      model = instance_exec(user, **api_params, &info.data_block)
-      { data: ArSync.sync_serialize(model, user, request['query']) }
+      begin
+        model = instance_exec(user, **api_params, &info.data_block)
+        { data: ArSync.sync_serialize(model, user, request['query']) }
+      rescue ActiveRecord::RecordNotFound => e
+        { error: { type: 'Record Not Found', message: e.message } }
+      end
     end
   end
 


### PR DESCRIPTION
root fieldが404エラーではなくnilを返した時
reload queryを直接使って[]が返った時
のバグ直した #123
