### PR TITLE
fix subscribe while reconnecting

### DIFF
--- a/core/ArSyncStore.js
+++ b/core/ArSyncStore.js
@@ -295,10 +295,7 @@ var ArSyncRecord = /** @class */ (function (_super) {
         return _this;
     }
     ArSyncRecord.prototype.setSyncKeys = function (sync_keys) {
-        this.sync_keys = sync_keys;
-        if (!this.sync_keys) {
-            this.sync_keys = [];
-        }
+        this.sync_keys = sync_keys !== null && sync_keys !== void 0 ? sync_keys : [];
     };
     ArSyncRecord.prototype.replaceData = function (data) {
         this.setSyncKeys(data.sync_keys);

--- a/core/ConnectionManager.d.ts
+++ b/core/ConnectionManager.d.ts
@@ -11,7 +11,7 @@ export default class ConnectionManager {
         unsubscribe: () => void;
     };
     subscribe(key: any, func: any): {
-        unsubscribe: () => void;
+        unsubscribe(): void;
     };
     connect(key: any): any;
     disconnect(key: any): void;

--- a/core/ConnectionManager.js
+++ b/core/ConnectionManager.js
@@ -40,6 +40,8 @@ var ConnectionManager = /** @class */ (function () {
     };
     ConnectionManager.prototype.subscribe = function (key, func) {
         var _this = this;
+        if (!this.networkStatus)
+            return { unsubscribe: function () { } };
         var subscription = this.connect(key);
         var id = subscription.serial++;
         subscription.ref++;

--- a/src/core/ArSyncStore.ts
+++ b/src/core/ArSyncStore.ts
@@ -251,11 +251,8 @@ class ArSyncRecord extends ArSyncContainerBase {
     this.children = {}
     this.replaceData(data)
   }
-  setSyncKeys(sync_keys: string[]) {
-    this.sync_keys = sync_keys
-    if (!this.sync_keys) {
-      this.sync_keys = []
-    }
+  setSyncKeys(sync_keys: string[] | undefined) {
+    this.sync_keys = sync_keys ?? []
   }
   replaceData(data) {
     this.setSyncKeys(data.sync_keys)

--- a/src/core/ConnectionManager.ts
+++ b/src/core/ConnectionManager.ts
@@ -38,6 +38,7 @@ export default class ConnectionManager {
     return { unsubscribe }
   }
   subscribe(key, func) {
+    if (!this.networkStatus) return { unsubscribe(){} }
     const subscription = this.connect(key)
     const id = subscription.serial++
     subscription.ref++


### PR DESCRIPTION
接続が切れている間にnew ArSyncModelが実行されると変になっていた

1. reconnecting中のsubscribeで、ConnectionManagerの中では接続済み扱いにしてしまっていた
2. reconnect後の再subscribeが実行されない(1ですでに接続済みだと勘違いしている)

接続されてない時のsubscribeはno-opにした
