### PR TITLE
Delete before fetch bugfix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.7', '3.0', '3.1' ]
+        ruby: [ '3.0', '3.1', '3.2', '3.3' ]
         gemfiles:
           - gemfiles/Gemfile-rails-6
           - gemfiles/Gemfile-rails-7

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,15 +23,10 @@ GEM
     ar_serializer (1.2.0)
       activerecord
       top_n_loader
-    coderay (1.1.3)
     concurrent-ruby (1.1.10)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
-    method_source (1.0.0)
     minitest (5.15.0)
-    pry (0.14.1)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
     rake (13.0.6)
     sqlite3 (1.4.2)
     top_n_loader (1.0.2)
@@ -46,7 +41,6 @@ DEPENDENCIES
   activerecord-import
   ar_serializer
   ar_sync!
-  pry
   rake
   sqlite3
 

--- a/ar_sync.gemspec
+++ b/ar_sync.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activerecord'
   spec.add_dependency 'ar_serializer'
-  %w[rake pry sqlite3 activerecord-import].each do |gem_name|
+  %w[rake sqlite3 activerecord-import].each do |gem_name|
     spec.add_development_dependency gem_name
   end
 end

--- a/bin/console
+++ b/bin/console
@@ -2,10 +2,10 @@
 
 require 'bundler/setup'
 require 'ar_sync'
-require 'pry'
+require 'irb'
 require_relative '../test/model'
 ArSync.on_notification do |events|
   puts "\e[1m#{events.inspect}\e[m"
 end
 
-Pry.start
+IRB.start

--- a/test/helper/test_runner.rb
+++ b/test/helper/test_runner.rb
@@ -76,23 +76,16 @@ class TestRunner
   def assert_script(code, **options, &block)
     timeout = options.has_key?(:timeout) ? options.delete(:timeout) : 1
     start = Time.now
-    raise if block ? options.size != 0 : options.size >= 2
 
     if options.empty?
       block ||= :itself.to_proc
     else
-      key, value = options.entries.first
-      /^(?<reversed>not_)?to_(?<verb>.+)/ =~ key
-      test = lambda do |v|
-        if verb == 'be'
-          v == value
-        else
-          v.send verb + '?', value
-        end
-      end
       block = lambda do |v|
-        f = test.call(v)
-        reversed ? !f : f
+        options.all? do |key, value|
+          /^(?<reversed>not_)?to_(?<verb>.+)/ =~ key
+          result = verb == 'be' ? v == value : v.send(verb + '?', value)
+          reversed ? !result : result
+        end
       end
     end
     return true if block.call eval_script(code)


### PR DESCRIPTION
has_manyなデータを作成→(追加通知が来る)→Fetch→(ここで誰かが削除、削除通知が来る)→Fetch完了
の時、削除通知が来たものの何も消さず、追加されたままになる不具合の修正
