### PR TITLE
Fix silencing of deprecation messages

### DIFF
--- a/lib/ar_sync/rails.rb
+++ b/lib/ar_sync/rails.rb
@@ -116,7 +116,8 @@ module ArSync
     end
 
     def log_internal_exception(exception)
-      ActiveSupport::Deprecation.silence do
+      deprecator = ::Rails.version >= Gem::Version.new('7.1.0') ? ::Rails.application.deprecators : ActiveSupport::Deprecation
+      deprecator.silence do
         logger.fatal '  '
         logger.fatal "#{exception.class} (#{exception.message}):"
         log_internal_exception_trace exception.annoted_source_code if exception.respond_to?(:annoted_source_code)


### PR DESCRIPTION
`ActiveSupport::Deprecation.silence` was deprecated on Rails 7.1[^1] and removed by Rails 7.2[^2].

Now we need to use `Rails.application.deprecators.silence` to silence all deprecation messages.

[^1]: https://github.com/rails/rails/pull/47354
[^2]: https://github.com/rails/rails/commit/c682bf26417f2a88b0efa46499e94dcf45955f4f