### PR TITLE
Change typing of application specific ArSyncModel export

### DIFF
--- a/lib/ar_sync/type_script.rb
+++ b/lib/ar_sync/type_script.rb
@@ -53,10 +53,14 @@ module ArSync::TypeScript
       import { TypeRequest } from './types'
       import DataTypeFromRequest from './DataTypeFromRequest'
       import { default as ArSyncModelBase } from 'ar_sync/core/ArSyncModel'
-      declare class ArSyncModel<R extends TypeRequest> extends ArSyncModelBase<DataTypeFromRequest<R>> {
-        constructor(r: R, option?: { immutable: boolean })
+      import ConnectionAdapter from 'ar_sync/core/ConnectionAdapter'
+
+      type ArSyncModel<R extends TypeRequest> = ArSyncModelBase<DataTypeFromRequest<R>>
+      const ArSyncModel = ArSyncModelBase as unknown as {
+        new <R extends TypeRequest>(r: R, option?: { immutable: boolean }): ArSyncModel<R>
+        setConnectionAdapter(adapter: ConnectionAdapter): void
       }
-      export default ArSyncModelBase as typeof ArSyncModel
+      export default ArSyncModel
     CODE
   end
 

--- a/test/ts_test.rb
+++ b/test/ts_test.rb
@@ -26,5 +26,9 @@ class TsTest < Minitest::Test
     output = output.lines.grep(/type_test/)
     puts output
     assert output.empty?
+
+    output = `./node_modules/typescript/bin/tsc --lib es2017,dom --noEmit test/generated_typed_files/*.ts`
+    puts output
+    assert output.empty?
   end
 end

--- a/test/type_test.ts
+++ b/test/type_test.ts
@@ -5,6 +5,7 @@ import * as ActionCable from 'actioncable'
 ArSyncModel.setConnectionAdapter(new ActionCableAdapter(ActionCable))
 
 type IsEqual<T, U> = [T, U] extends [U, T] ? true : false
+type IsNotEqual<T, U> = IsEqual<T, U> extends true ? false : true
 function isOK<T extends true>(): T | undefined { return }
 type IsStrictMode = string | null extends string ? false : true
 type TypeIncludes<T extends {}, U extends {}> = IsEqual<Pick<T, keyof T & keyof U>, U>
@@ -13,6 +14,7 @@ isOK<IsStrictMode>()
 
 const [hooksData1] = useArSyncModel({ api: 'currentUser', query: 'id' })
 isOK<IsEqual<typeof hooksData1, { id: number } | null>>()
+isOK<IsNotEqual<typeof hooksData1, { id: string } | null>>()
 const [hooksData2] = useArSyncModel({ api: 'currentUser', query: { '*': true, foo: true } })
 isOK<HasExtraField<typeof hooksData2, 'foo'>>()
 const [hooksData3] = useArSyncFetch({ api: 'currentUser', query: 'id' })
@@ -22,6 +24,7 @@ isOK<HasExtraField<typeof hooksData4, 'foo'>>()
 
 const data1 = new ArSyncModel({ api: 'currentUser', query: 'id' }).data!
 isOK<IsEqual<typeof data1, { id: number }>>()
+isOK<IsNotEqual<typeof data1, { id: string }>>()
 const data2 = new ArSyncModel({ api: 'currentUser', query: ['id', 'name'] }).data!
 isOK<IsEqual<typeof data2, { id: number; name: string | null }>>()
 const data3 = new ArSyncModel({ api: 'currentUser', query: '*' }).data!


### PR DESCRIPTION
To eliminate "is defined but only used as a type" warning