### PR TITLE
Subscribe detail type

### DIFF
--- a/core/ArSyncModel.d.ts
+++ b/core/ArSyncModel.d.ts
@@ -8,8 +8,13 @@ interface Change {
 declare type ChangeCallback = (change: Change) => void;
 declare type LoadCallback = () => void;
 declare type ConnectionCallback = (status: boolean) => void;
-declare type SubscriptionType = 'load' | 'change' | 'connection' | 'destroy';
-declare type SubscriptionCallback = ChangeCallback | LoadCallback | ConnectionCallback;
+declare type SubscriptionCallbackMap = {
+    load: LoadCallback;
+    change: ChangeCallback;
+    connection: ConnectionCallback;
+    destroy: LoadCallback;
+};
+declare type SubscriptionType = keyof SubscriptionCallbackMap;
 declare type ArSyncModelRef = {
     key: string;
     count: number;
@@ -44,12 +49,12 @@ export default class ArSyncModel<T> {
         immutable: boolean;
     });
     onload(callback: LoadCallback): void;
-    subscribeOnce(event: SubscriptionType, callback: SubscriptionCallback): {
+    subscribeOnce<T extends SubscriptionType>(event: T, callback: SubscriptionCallbackMap[T]): {
         unsubscribe: () => void;
     };
     dig<P extends Path>(path: P): DigResult<T, P> | null;
     static digData<Data, P extends Path>(data: Data, path: P): DigResult<Data, P>;
-    subscribe(event: SubscriptionType, callback: SubscriptionCallback): {
+    subscribe<T extends SubscriptionType>(event: T, callback: SubscriptionCallbackMap[T]): {
         unsubscribe: () => void;
     };
     release(): void;

--- a/core/ArSyncModel.js
+++ b/core/ArSyncModel.js
@@ -29,8 +29,8 @@ var ArSyncModel = /** @class */ (function () {
         this.subscribeOnce('load', callback);
     };
     ArSyncModel.prototype.subscribeOnce = function (event, callback) {
-        var subscription = this.subscribe(event, function (arg) {
-            callback(arg);
+        var subscription = this.subscribe(event, function (e) {
+            callback(e);
             subscription.unsubscribe();
         });
         return subscription;

--- a/core/ArSyncStore.d.ts
+++ b/core/ArSyncStore.d.ts
@@ -2,8 +2,9 @@ export declare type Request = {
     api: string;
     query: any;
     params?: any;
-    id?: any;
+    id?: IDType;
 };
+declare type IDType = number | string;
 export declare class ArSyncStore {
     immutable: boolean;
     markedForFreezeObjects: any[];
@@ -34,3 +35,4 @@ export declare class ArSyncStore {
     freezeMarked(): void;
     release(): void;
 }
+export {};


### PR DESCRIPTION
`model.subscribe('change', e => {})` will be typed correctly